### PR TITLE
Fix README duplicate bullet and stray heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,11 +257,6 @@ python -m scanner_gui.main
 - Select the scanner port from the dropdown and click "Connect".
 - Use the sliders, buttons, and keypad to control the scanner.
 - View real-time updates on the display and signal meters.
-- Select the scanner port from the dropdown and click "Connect".
-
-## Extending the System buttons, and keypad to control the scanner.
-
-- View real-time updates on the display and signal meters.
 
 ### Adding New Scanner Models
 


### PR DESCRIPTION
## Summary
- clean up README usage section

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f713d38fc8324a461835c2f285ad6