### PR TITLE
Fix duplicate raise in command parsing

### DIFF
--- a/tests/test_command_library.py
+++ b/tests/test_command_library.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from utilities.command_library import scanner_command
+
+
+def test_parse_response_ok():
+    cmd = scanner_command('TEST')
+    assert cmd.parseResponse('OK') == 'OK'
+
+
+def test_parse_response_error():
+    cmd = scanner_command('TEST')
+    with pytest.raises(Exception):
+        cmd.parseResponse('ERR')

--- a/utilities/command_library.py
+++ b/utilities/command_library.py
@@ -119,7 +119,4 @@ class scanner_command:
             raise Exception(
                 f"{self.name}: Command returned an error: {response}"
             )
-            raise Exception(
-                f"{self.name}: Command returned an error: {response}"
-            )
         return self.parser(response) if self.parser else response


### PR DESCRIPTION
## Summary
- fix duplicated error handling in `scanner_command.parseResponse`
- add tests for parseResponse behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6f245d808324a71d1fb25392bf32