### PR TITLE
Fix response parsing for non-error messages containing ERR

### DIFF
--- a/tests/test_command_library.py
+++ b/tests/test_command_library.py
@@ -16,3 +16,9 @@ def test_parse_response_error():
     cmd = scanner_command('TEST')
     with pytest.raises(Exception):
         cmd.parseResponse('ERR')
+
+
+def test_parse_response_err_substring():
+    cmd = scanner_command('TEST')
+    # Ensure substring 'ERR' within a valid response does not raise
+    assert cmd.parseResponse('CARRIER') == 'CARRIER'

--- a/utilities/command_library.py
+++ b/utilities/command_library.py
@@ -115,7 +115,10 @@ class scanner_command:
             Exception: If the response contains an error.
         """
         response = response.strip()
-        if response == "ERR" or "ERR" in response:
+        # Treat only explicit error responses as errors. Some valid responses
+        # may contain the substring "ERR" (e.g. "CARRIER"), so we check for
+        # an actual error prefix instead of using ``in``.
+        if response.upper().startswith("ERR"):
             raise Exception(
                 f"{self.name}: Command returned an error: {response}"
             )

--- a/utilities/command_library.py
+++ b/utilities/command_library.py
@@ -119,7 +119,7 @@ class scanner_command:
         # may contain the substring "ERR" (e.g. "CARRIER"), so we check for
         # an actual error prefix instead of using ``in``.
         if response.upper().startswith("ERR"):
-            raise Exception(
+            raise CommandError(
                 f"{self.name}: Command returned an error: {response}"
             )
         return self.parser(response) if self.parser else response

--- a/utilities/shared_utils.py
+++ b/utilities/shared_utils.py
@@ -98,7 +98,9 @@ class scanner_command:
             Exception: If the response contains an error.
         """
         response = response.strip()
-        if response == "ERR" or "ERR" in response:
+        # Some valid responses can include the substring "ERR" (e.g. "CARRIER").
+        # Consider it an error only when the response actually begins with "ERR".
+        if response.upper().startswith("ERR"):
             raise Exception(
                 f"{self.name}: Command returned an error: {response}"
             )

--- a/utilities/shared_utils.py
+++ b/utilities/shared_utils.py
@@ -101,7 +101,7 @@ class scanner_command:
         # Some valid responses can include the substring "ERR" (e.g. "CARRIER").
         # Consider it an error only when the response actually begins with "ERR".
         if response.upper().startswith("ERR"):
-            raise Exception(
+            raise CommandError(
                 f"{self.name}: Command returned an error: {response}"
             )
         return self.parser(response) if self.parser else response


### PR DESCRIPTION
## Summary
- avoid false error detection in `parseResponse`
- ensure same logic is used in shared utilities
- test for substring `ERR` in command responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7e070bb4832487e03752f13642f0