### PR TITLE
Add documentation for new tests

### DIFF
--- a/tests/test_help_utils.py
+++ b/tests/test_help_utils.py
@@ -1,0 +1,45 @@
+"""Tests for :func:`utilities.command.help_utils.process_adapter_commands`."""
+
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import types
+
+serial_stub = types.ModuleType("serial")
+serial_stub.Serial = lambda *a, **k: None
+serial_tools_stub = types.ModuleType("serial.tools")
+list_ports_stub = types.ModuleType("serial.tools.list_ports")
+list_ports_stub.comports = lambda *a, **k: []
+serial_tools_stub.list_ports = list_ports_stub
+serial_stub.tools = serial_tools_stub
+sys.modules.setdefault("serial.tools", serial_tools_stub)
+sys.modules.setdefault("serial.tools.list_ports", list_ports_stub)
+sys.modules.setdefault("serial", serial_stub)
+
+
+from utilities.command.help_utils import process_adapter_commands
+
+
+class DummyCmd:
+    def __init__(self, module=None):
+        self.source_module = module
+
+
+class DummyAdapter:
+    def __init__(self):
+        self.commands = {
+            "foo": DummyCmd("foo_commands"),
+            "bar": DummyCmd(),
+            "get volume": DummyCmd("volume_commands"),
+        }
+
+
+def test_process_adapter_commands_basic():
+    general = {"Get Commands": ["get volume"]}
+    categories, groups = process_adapter_commands(DummyAdapter(), general)
+
+    assert "Foo" in categories
+    assert "Other" in categories
+    assert groups == {"Foo": ["foo"], "Other": ["bar"]}
+    assert "Volume" not in groups

--- a/tests/test_log_trim.py
+++ b/tests/test_log_trim.py
@@ -1,0 +1,26 @@
+"""Tests for :func:`utilities.tools.log_trim.trim_log_file`."""
+
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utilities.tools.log_trim import trim_log_file
+
+
+def test_trim_log_file(tmp_path):
+    log = tmp_path / "test.log"
+    original = b"a" * 2048
+    log.write_bytes(original)
+
+    trim_log_file(str(log), max_size=1024)
+
+    data = log.read_bytes()
+    assert len(data) == 1024
+    assert data == original[-1024:]
+
+
+def test_trim_log_file_missing(tmp_path):
+    missing = tmp_path / "missing.log"
+    trim_log_file(str(missing))
+    assert not missing.exists()

--- a/tests/test_log_utils_extra.py
+++ b/tests/test_log_utils_extra.py
@@ -1,0 +1,31 @@
+"""Additional tests for :mod:`utilities.log_utils`."""
+
+import logging
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utilities.log_utils import configure_logging
+
+
+def _clear_root_handlers():
+    root = logging.getLogger("")
+    for h in list(root.handlers):
+        root.removeHandler(h)
+
+
+def test_configure_logging_creates_file_and_level(tmp_path):
+    _clear_root_handlers()
+    log_file = tmp_path / "app.log"
+    configure_logging(str(log_file), level=logging.WARNING)
+    assert log_file.exists()
+    assert logging.getLogger("").level == logging.WARNING
+
+
+def test_configure_logging_trims_large_file(tmp_path):
+    log_file = tmp_path / "big.log"
+    log_file.write_bytes(b"a" * 2048)
+    _clear_root_handlers()
+    configure_logging(str(log_file), level=logging.INFO, max_size_mb=0)
+    assert os.path.getsize(log_file) < 2048

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,36 @@
+"""Unit tests for the :mod:`utilities.command.parser` module."""
+
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utilities.command.parser import parse_command
+
+
+def test_parse_command_aliases_and_multiword():
+    commands = {
+        "get freq": None,
+        "set option": None,
+        "scan start": None,
+    }
+
+    cmd, args = parse_command("read freq", commands)
+    assert cmd == "get freq"
+    assert args == ""
+
+    cmd, args = parse_command("write option 1", commands)
+    assert cmd == "set option"
+    assert args == "1"
+
+    cmd, args = parse_command("scan start now", commands)
+    assert cmd == "scan start"
+    assert args == "now"
+
+
+def test_parse_command_unknown():
+    commands = {}
+    cmd, args = parse_command("foo bar baz", commands)
+    assert cmd == "foo"
+    assert args == "bar baz"

--- a/tests/test_timeout_utils.py
+++ b/tests/test_timeout_utils.py
@@ -1,0 +1,37 @@
+"""Tests for the timeout utility decorator in :mod:`utilities.io.timeout_utils`."""
+
+import os
+import sys
+import time
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utilities.io.timeout_utils import with_timeout, ScannerTimeoutError
+
+
+def test_with_timeout_success():
+    @with_timeout(1)
+    def quick():
+        return "done"
+
+    assert quick() == "done"
+
+
+def test_with_timeout_error():
+    @with_timeout(0.1)
+    def slow():
+        time.sleep(0.2)
+        return "late"
+
+    with pytest.raises(ScannerTimeoutError):
+        slow()
+
+
+def test_with_timeout_default_value():
+    @with_timeout(0.1, default_result="default")
+    def slow():
+        time.sleep(0.2)
+        return "late"
+
+    assert slow() == "default"


### PR DESCRIPTION
## Summary
- document new test modules with short module docstrings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f8714461c832486a30fd8d78e32a0