### PR TITLE
Define CommandError exception

### DIFF
--- a/utilities/command_library.py
+++ b/utilities/command_library.py
@@ -7,6 +7,7 @@ commands for a scanner tool, with validation and logging capabilities.
 
 # Import centralized logging utilities
 from utilities.log_utils import get_logger
+from utilities.errors import CommandError
 
 # Get a logger for this module
 logger = get_logger(__name__)

--- a/utilities/errors.py
+++ b/utilities/errors.py
@@ -1,0 +1,7 @@
+"""Custom exceptions for the scanner controller utilities."""
+
+class CommandError(Exception):
+    """Raised when a scanner command returns an error response."""
+
+    pass
+

--- a/utilities/shared_utils.py
+++ b/utilities/shared_utils.py
@@ -7,6 +7,8 @@ It includes serial buffer management and command handling.
 import logging
 import time
 
+from utilities.errors import CommandError
+
 
 class scanner_command:
     """


### PR DESCRIPTION
## Summary
- add `CommandError` exception for scanner commands
- import the new exception in `shared_utils` and `command_library`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684072d56108832482a3707b4bd37d5b