### PR TITLE
Add more unit tests

### DIFF
--- a/tests/test_command_library.py
+++ b/tests/test_command_library.py
@@ -29,3 +29,22 @@ def test_parse_response_err_substring():
     """Treat responses containing ``ERR`` as valid if not prefixed by it."""
     cmd = scanner_command("TEST")
     assert cmd.parse_response("CARRIER") == "CARRIER"
+
+
+def test_build_command_query():
+    """Return query string when no value is provided."""
+    cmd = scanner_command("FREQ")
+    assert cmd.build_command() == "FREQ\r"
+
+
+def test_build_command_set_valid():
+    """Build set command when value is in range."""
+    cmd = scanner_command("VOL", valid_range=(0, 10))
+    assert cmd.build_command(5) == "VOL,5\r"
+
+
+def test_build_command_set_invalid():
+    """Raise ``ValueError`` when value is outside the allowed range."""
+    cmd = scanner_command("SQUELCH", valid_range=(0, 100))
+    with pytest.raises(ValueError):
+        cmd.build_command(150)

--- a/tests/test_scanner_manager.py
+++ b/tests/test_scanner_manager.py
@@ -1,0 +1,57 @@
+"""Tests for functions in :mod:`utilities.scanner.manager`."""
+
+import os
+import sys
+import types
+
+import pytest
+
+# Ensure ``utilities`` is importable
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide a minimal serial stub before importing the module
+serial_stub = types.ModuleType("serial")
+serial_stub.Serial = lambda *a, **k: None
+sys.modules.setdefault("serial", serial_stub)
+
+from utilities.scanner import manager  # noqa: E402
+
+
+def test_scan_for_scanners_no_devices(monkeypatch):
+    """Return an error string when no scanners are found."""
+    monkeypatch.setattr(manager, "find_all_scanner_ports", lambda: [])
+    assert manager.scan_for_scanners() == "STATUS:ERROR|CODE:NO_SCANNERS_FOUND"
+
+
+def test_scan_for_scanners_multiple(monkeypatch):
+    """Format output correctly for multiple detected scanners."""
+    monkeypatch.setattr(
+        manager,
+        "find_all_scanner_ports",
+        lambda: [("COM1", "ModelA"), ("COM2", "ModelB")],
+    )
+    result = manager.scan_for_scanners()
+    assert result == (
+        "STATUS:OK|SCANNERS_FOUND:2|"
+        "SCANNER:1|PORT:COM1|MODEL:ModelA|"
+        "SCANNER:2|PORT:COM2|MODEL:ModelB"
+    )
+
+
+def test_connect_to_scanner_invalid_input(monkeypatch):
+    """Return an error when the scanner ID is not a number."""
+    assert manager.connect_to_scanner("abc") == (
+        "STATUS:ERROR|CODE:INVALID_SCANNER_ID|MESSAGE:Scanner_ID_must_be_a_number"
+    )
+
+
+def test_connect_to_scanner_no_scanners(monkeypatch):
+    """Return an error when no scanners are detected."""
+    monkeypatch.setattr(manager, "find_all_scanner_ports", lambda: [])
+    assert manager.connect_to_scanner("1") == "STATUS:ERROR|CODE:NO_SCANNERS_FOUND"
+
+
+def test_connect_to_scanner_id_out_of_range(monkeypatch):
+    """Return an error when the ID is outside the detected range."""
+    monkeypatch.setattr(manager, "find_all_scanner_ports", lambda: [("COM1", "X")])
+    assert manager.connect_to_scanner("2") == "STATUS:ERROR|CODE:INVALID_SCANNER_ID|MAX_ID:1"

--- a/tests/test_timeout_utils.py
+++ b/tests/test_timeout_utils.py
@@ -45,3 +45,17 @@ def test_with_timeout_default_value():
         return "late"
 
     assert slow() == "default"
+
+
+def test_with_timeout_propagates_exception():
+    """Exceptions raised inside the wrapped function are re-raised."""
+
+    class CustomError(Exception):
+        pass
+
+    @with_timeout(1)
+    def bad():
+        raise CustomError("boom")
+
+    with pytest.raises(CustomError):
+        bad()


### PR DESCRIPTION
## Summary
- add scanner_command build_command tests
- improve timeout_utils test coverage
- cover scanner.manager error paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68408f6894f483248b40783d65ba5d8e