### PR TITLE
Fix pre-commit hooks paths

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,14 +35,14 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: .venv/Scripts/pytest.exe
+        entry: python -m pytest
         language: system
         pass_filenames: false
         types: [python]
 
       - id: isort
         name: isort
-        entry: .venv/Scripts/isort.exe
+        entry: python -m isort
         language: system
         types: [python]
         args: ["--profile", "black"]


### PR DESCRIPTION
## Summary
- use module invocations in local pre-commit hooks so Windows and Unix can run them

## Testing
- `pytest -q`
- `pre-commit run --files .pre-commit-config.yaml` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6840cfcf90e083249319fec03666b7f7