### PR TITLE
Implement scanning controls

### DIFF
--- a/adapters/uniden/bcd325p2/user_control.py
+++ b/adapters/uniden/bcd325p2/user_control.py
@@ -35,3 +35,13 @@ def send_key(self, ser, key_seq):
             success = False
 
     return self.feedback(success, "\n".join(responses))
+
+
+def start_scanning(self, ser):
+    """Resume scanning mode."""
+    return self.send_key(ser, "S")
+
+
+def stop_scanning(self, ser):
+    """Hold on current channel/frequency."""
+    return self.send_key(ser, "H")

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -33,7 +33,11 @@ from adapters.uniden.bcd325p2.status_info import (
     read_sw_ver,
     read_window_voltage,
 )
-from adapters.uniden.bcd325p2.user_control import send_key
+from adapters.uniden.bcd325p2.user_control import (
+    send_key,
+    start_scanning,
+    stop_scanning,
+)
 
 # Import common functions
 from adapters.uniden.common.core import (
@@ -131,6 +135,8 @@ class BCD325P2Adapter(UnidenScannerAdapter):
 
     # User control methods
     send_key = send_key
+    start_scanning = start_scanning
+    stop_scanning = stop_scanning
 
     def get_help(self, command):
         """Get help for a specific BCD325P2 command.

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -1,0 +1,33 @@
+"""Tests for build_command_table scanning commands."""
+
+import os
+import sys
+import types
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide minimal serial stub
+serial_stub = types.ModuleType("serial")
+serial_stub.Serial = lambda *a, **k: None
+sys.modules.setdefault("serial", serial_stub)
+
+from utilities.core.command_registry import build_command_table  # noqa: E402
+from adapters.uniden.bcd325p2_adapter import BCD325P2Adapter  # noqa: E402
+
+
+def test_scan_start_stop_registered(monkeypatch):
+    """``build_command_table`` registers scan start/stop for BCD325P2."""
+    adapter = BCD325P2Adapter()
+    # Stub out send_key to avoid serial I/O
+    monkeypatch.setattr(adapter, "send_key", lambda ser, seq: f"KEY:{seq}")
+
+    commands, help_text = build_command_table(adapter, None)
+
+    assert "scan start" in commands
+    assert "scan stop" in commands
+    assert help_text["scan start"] == "Start scanner scanning process."
+    assert help_text["scan stop"] == "Stop scanner scanning process."
+
+    # Ensure commands use adapter methods
+    assert commands["scan start"]() == "KEY:S"
+    assert commands["scan stop"]() == "KEY:H"


### PR DESCRIPTION
## Summary
- add `start_scanning` and `stop_scanning` helpers for BCD325P2
- expose these helpers from the adapter so command registry can register
- verify command registration with new unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841de4ca6088324a3a8aa41023f7d2a