### PR TITLE
Add Close Call helpers and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The application dynamically detects connected scanner models and loads the appro
 - **Keypad**: Input numeric values and commands using a keypad.
 - **Rotary Knob**: Simulate a rotary knob for navigation and selection.
 - **Port Detection**: Automatically detect and connect to supported scanner models via serial ports.
+- **Close Call Controls**: Manage Close Call settings and jump commands through adapter helpers.
 
 ## Supported Scanner Models
 

--- a/adapters/uniden/bcd325p2/close_call.py
+++ b/adapters/uniden/bcd325p2/close_call.py
@@ -1,0 +1,23 @@
+"""Close Call helper functions for the BCD325P2 scanner."""
+
+
+def get_close_call(self, ser):
+    """Return current Close Call settings (raw CLC response)."""
+    return self.send_command(ser, "CLC")
+
+
+def set_close_call(self, ser, params):
+    """Set Close Call parameters using ``CLC`` command."""
+    if isinstance(params, (list, tuple)):
+        params = ",".join(str(x) for x in params)
+    return self.send_command(ser, f"CLC,{params}")
+
+
+def jump_mode(self, ser, jump_mode, index=""):
+    """Jump to the specified mode and index."""
+    return self.send_command(ser, f"JPM,{jump_mode},{index}")
+
+
+def jump_to_number_tag(self, ser, sys_tag="", chan_tag=""):
+    """Jump to a system and channel number tag."""
+    return self.send_command(ser, f"JNT,{sys_tag},{chan_tag}")

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -25,6 +25,12 @@ from adapters.uniden.bcd325p2.frequency import (
     read_frequency,
     write_frequency,
 )
+from adapters.uniden.bcd325p2.close_call import (
+    get_close_call,
+    jump_mode,
+    jump_to_number_tag,
+    set_close_call,
+)
 from adapters.uniden.bcd325p2.status_info import (
     read_battery_voltage,
     read_model,
@@ -132,6 +138,12 @@ class BCD325P2Adapter(UnidenScannerAdapter):
     read_channel_info = read_channel_info
     write_channel_info = write_channel_info
     read_global_lockout = read_global_lockout
+
+    # Close Call methods
+    get_close_call = get_close_call
+    set_close_call = set_close_call
+    jump_mode = jump_mode
+    jump_to_number_tag = jump_to_number_tag
 
     # User control methods
     send_key = send_key

--- a/tests/test_adapter_close_call.py
+++ b/tests/test_adapter_close_call.py
@@ -1,0 +1,39 @@
+"""Tests for BCD325P2Adapter close call helpers and scan controls."""
+
+import os
+import sys
+import types
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide minimal serial stub
+serial_stub = types.ModuleType("serial")
+serial_stub.Serial = lambda *a, **k: None
+sys.modules.setdefault("serial", serial_stub)
+
+from adapters.uniden.bcd325p2_adapter import BCD325P2Adapter  # noqa: E402
+
+
+def test_scan_controls_return_raw(monkeypatch):
+    """start_scanning and stop_scanning return raw responses."""
+    adapter = BCD325P2Adapter()
+    monkeypatch.setattr(adapter, "send_key", lambda ser, seq: f"KEY:{seq}")
+
+    assert adapter.start_scanning(None) == "KEY:S"
+    assert adapter.stop_scanning(None) == "KEY:H"
+
+
+def test_close_call_helpers_raw(monkeypatch):
+    """Close Call helper methods pass through send_command."""
+    adapter = BCD325P2Adapter()
+    monkeypatch.setattr(adapter, "send_command", lambda ser, cmd: f"CMD:{cmd}")
+
+    assert adapter.get_close_call(None) == "CMD:CLC"
+    assert adapter.set_close_call(None, [0, 1, 2]) == "CMD:CLC,0,1,2"
+    assert adapter.set_close_call(None, "0,1,2") == "CMD:CLC,0,1,2"
+    assert adapter.jump_mode(None, "SCN_MODE", "5") == "CMD:JPM,SCN_MODE,5"
+    assert adapter.jump_mode(None, "CC_MODE") == "CMD:JPM,CC_MODE,"
+    assert (
+        adapter.jump_to_number_tag(None, "1", "2") == "CMD:JNT,1,2"
+    )
+    assert adapter.jump_to_number_tag(None) == "CMD:JNT,,"

--- a/utilities/command/help_topics.py
+++ b/utilities/command/help_topics.py
@@ -79,6 +79,17 @@ Examples:
 
 Note: This can take several minutes to complete.
 """,
+    "closecall": """
+Close Call Commands:
+-------------------
+The adapter exposes helper methods to control the Close Call feature.
+
+Methods:
+  get_close_call       - return raw CLC settings
+  set_close_call       - send new CLC parameters
+  jump_mode            - jump to a search or Close Call mode
+  jump_to_number_tag   - jump to a system/channel number tag
+""",
 }
 
 


### PR DESCRIPTION
## Summary
- add `close_call` helper functions for BCD325P2
- expose helpers through `BCD325P2Adapter`
- document Close Call controls in README and help topics
- test scan start/stop and Close Call helper behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e0fe3964832493d8b95e1479d485