### PR TITLE
Expose BCD325P2 Close Call commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The application dynamically detects connected scanner models and loads the appro
 - **Keypad**: Input numeric values and commands using a keypad.
 - **Rotary Knob**: Simulate a rotary knob for navigation and selection.
 - **Port Detection**: Automatically detect and connect to supported scanner models via serial ports.
+- **Scanning Control**: Start or stop scanning directly from the interface and access Close Call operations.
 
 ## Supported Scanner Models
 

--- a/adapters/uniden/bcd325p2/close_call.py
+++ b/adapters/uniden/bcd325p2/close_call.py
@@ -1,0 +1,28 @@
+"""Close Call operations for the BCD325P2 scanner."""
+
+
+def get_close_call(self, ser):
+    """Return the current Close Call settings."""
+    return self.send_command(ser, "CLC")
+
+
+def set_close_call(self, ser, params):
+    """Set Close Call parameters.
+
+    ``params`` may be a string or a sequence of values which will be joined
+    with commas.
+    """
+    if isinstance(params, (list, tuple)):
+        params = ",".join(str(p) for p in params)
+    return self.send_command(ser, f"CLC,{params}")
+
+
+def jump_mode(self, ser, jump_mode, index=""):
+    """Jump to a specific mode using the JPM command."""
+    return self.send_command(ser, f"JPM,{jump_mode},{index}")
+
+
+def jump_to_number_tag(self, ser, sys_tag="", chan_tag=""):
+    """Jump to a system/channel number tag using the JNT command."""
+    return self.send_command(ser, f"JNT,{sys_tag},{chan_tag}")
+

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -38,6 +38,12 @@ from adapters.uniden.bcd325p2.user_control import (
     start_scanning,
     stop_scanning,
 )
+from adapters.uniden.bcd325p2.close_call import (
+    get_close_call,
+    set_close_call,
+    jump_mode,
+    jump_to_number_tag,
+)
 
 # Import common functions
 from adapters.uniden.common.core import (
@@ -137,6 +143,12 @@ class BCD325P2Adapter(UnidenScannerAdapter):
     send_key = send_key
     start_scanning = start_scanning
     stop_scanning = stop_scanning
+
+    # Close Call methods
+    get_close_call = get_close_call
+    set_close_call = set_close_call
+    jump_mode = jump_mode
+    jump_to_number_tag = jump_to_number_tag
 
     def get_help(self, command):
         """Get help for a specific BCD325P2 command.

--- a/tests/test_close_call_methods.py
+++ b/tests/test_close_call_methods.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import types
+
+# Ensure utilities can be imported
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide a minimal serial stub
+serial_stub = types.ModuleType("serial")
+serial_stub.Serial = lambda *a, **k: None
+sys.modules.setdefault("serial", serial_stub)
+
+from adapters.uniden.bcd325p2_adapter import BCD325P2Adapter  # noqa: E402
+
+
+def test_close_call_commands(monkeypatch):
+    """Adapter methods should format Close Call commands correctly."""
+    adapter = BCD325P2Adapter()
+
+    monkeypatch.setattr(
+        adapter,
+        "send_command",
+        lambda ser, cmd: f"CMD:{cmd}"
+    )
+
+    assert adapter.get_close_call(None) == "CMD:CLC"
+    assert adapter.set_close_call(None, "1,0") == "CMD:CLC,1,0"
+    assert adapter.set_close_call(None, [1, 0]) == "CMD:CLC,1,0"
+    assert adapter.jump_mode(None, "CC_MODE") == "CMD:JPM,CC_MODE,"
+    assert adapter.jump_mode(None, "SVC_MODE", "Racing") == "CMD:JPM,SVC_MODE,Racing"
+    assert adapter.jump_to_number_tag(None, "1", "2") == "CMD:JNT,1,2"
+    assert adapter.jump_to_number_tag(None) == "CMD:JNT,,"
+


### PR DESCRIPTION
## Summary
- implement Close Call helpers for the BCD325P2 adapter
- register the helpers on the adapter
- add unit tests for Close Call commands
- document scanning and Close Call features in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841dbe2bb5c83249bb3d6864562e708