### PR TITLE
Add generic Uniden adapter

### DIFF
--- a/adapters/uniden/__init__.py
+++ b/adapters/uniden/__init__.py
@@ -1,1 +1,5 @@
 """Uniden scanner adapter modules."""
+
+from .generic_adapter import GenericUnidenAdapter
+
+__all__ = ["GenericUnidenAdapter"]

--- a/adapters/uniden/generic_adapter.py
+++ b/adapters/uniden/generic_adapter.py
@@ -1,0 +1,16 @@
+"""Generic adapter for Uniden scanners."""
+
+from adapters.uniden.uniden_base_adapter import UnidenScannerAdapter
+from command_libraries.uniden.generic_commands import commands
+
+
+class GenericUnidenAdapter(UnidenScannerAdapter):
+    """A minimal adapter for Uniden scanners."""
+
+    def __init__(self, machine_mode: bool = False):
+        super().__init__(machine_mode, commands)
+        self.machine_mode_id = "UNIDEN"
+
+    def __str__(self) -> str:
+        mode = "machine" if self.machine_mode else "human"
+        return f"Uniden Adapter ({mode} mode)"

--- a/command_libraries/uniden/generic_commands.py
+++ b/command_libraries/uniden/generic_commands.py
@@ -1,0 +1,14 @@
+"""Generic command definitions for Uniden scanners."""
+
+commands = {}
+
+
+def get_help(command):
+    """Return help text for ``command`` if available."""
+    cmd = commands.get(command.upper())
+    return cmd.help if cmd else None
+
+
+def list_commands():
+    """Return a sorted list of available command names."""
+    return sorted(commands.keys())


### PR DESCRIPTION
## Summary
- add a minimal Uniden adapter
- supply a generic command library
- expose the adapter in the Uniden package

## Testing
- `flake8 adapters/uniden/generic_adapter.py command_libraries/uniden/generic_commands.py adapters/uniden/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ead77f048324bad22a4ba4b4977f