### PR TITLE
Fallback Uniden adapter for unknown models

### DIFF
--- a/tests/test_factory_uniden.py
+++ b/tests/test_factory_uniden.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import types
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+# Provide minimal serial stubs so the factory modules import cleanly
+serial_stub = types.ModuleType("serial")
+serial_stub.Serial = lambda *a, **k: None
+serial_tools_stub = types.ModuleType("serial.tools")
+list_ports_stub = types.ModuleType("serial.tools.list_ports")
+list_ports_stub.comports = lambda *a, **k: []
+serial_tools_stub.list_ports = list_ports_stub
+serial_stub.tools = serial_tools_stub
+sys.modules.setdefault("serial", serial_stub)
+sys.modules.setdefault("serial.tools", serial_tools_stub)
+sys.modules.setdefault("serial.tools.list_ports", list_ports_stub)
+
+from utilities.scanner.factory import get_scanner_adapter  # noqa: E402
+from utilities.core.adapter_factory import create_adapter  # noqa: E402
+
+
+def test_uniden_prefix_returns_generic_adapter():
+    adapter = get_scanner_adapter("SDS100")
+    assert adapter.__class__.__name__ == "GenericUnidenAdapter"
+
+
+def test_cli_factory_generic_uniden(monkeypatch):
+    adapter = create_adapter("sds200", machine_mode=True)
+    assert adapter.__class__.__name__ == "GenericUnidenAdapter"

--- a/utilities/scanner/factory.py
+++ b/utilities/scanner/factory.py
@@ -53,13 +53,22 @@ def get_scanner_adapter(model, machine_mode=False):
             from adapters.uniden.bc125at_adapter import BC125ATAdapter
 
             logging.info(f"Creating adapter for {model}")
-            return BC125ATAdapter()
+            return BC125ATAdapter(machine_mode=machine_mode)
         elif "BCD325P2" in model:
             from adapters.uniden.bcd325p2_adapter import BCD325P2Adapter
 
             logging.info(f"Creating adapter for {model}")
-            return BCD325P2Adapter()
+            return BCD325P2Adapter(machine_mode=machine_mode)
         else:
+            prefixes = ("BC", "BCD", "UBC", "SDS")
+            if any(model.startswith(prefix) for prefix in prefixes):
+                from adapters.uniden.generic_adapter import GenericUnidenAdapter
+
+                logging.info(
+                    f"Creating generic Uniden adapter for unrecognized model: {model}"
+                )
+                return GenericUnidenAdapter(machine_mode=machine_mode)
+
             logging.error(f"No adapter available for model: {model}")
             return None
     except Exception as e:


### PR DESCRIPTION
## Summary
- add GenericUnidenAdapter fallback to scanner factory
- add same behaviour for CLI adapter factory
- test the fallback logic

## Testing
- `pre-commit run --files utilities/scanner/factory.py utilities/core/adapter_factory.py tests/test_factory_uniden.py` *(fails: CONNECT tunnel failed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841eeafbd048324a79b3b2ed14d84a8