### PR TITLE
Add generic Uniden fallback note

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ The following scanner models are supported through the `commandLibrary`:
 
 - **BC125AT**: Uniden handheld scanner
 - **BCD325P2**: Uniden handheld digital scanner
+- **Generic Uniden**: Fallback adapter for other Uniden models. Unknown Uniden
+  scanners automatically use this fallback with basic volume and squelch
+  control.
 
 The code is designed to work with most Uniden scanners and is abstracted to allow easy porting to other manufacturers.
 


### PR DESCRIPTION
## Summary
- mention generic Uniden support in README
- note that unknown Uniden scanners default to this adapter with volume and squelch control

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f18410c48324b12c1953d682492f