### PR TITLE
Fix BSV naming regression

### DIFF
--- a/command_libraries/uniden/bcd325p2/freq_management_commands.py
+++ b/command_libraries/uniden/bcd325p2/freq_management_commands.py
@@ -29,17 +29,17 @@ FREQUENCY_MANAGEMENT_COMMANDS = {
         Lower limit, upper limit, step, offset, and modulation for the band
         """,
     ),
-    "BSV": ScannerCommand(
-        name="BSV",
+    "BSP": ScannerCommand(
+        name="BSP",
         requires_prg=False,
-        set_format="BSV,{sweep_operation}",
+        set_format="BSP,{sweep_operation}",
         validator=validate_param_constraints(
             [(int, {0, 1, 2})]  # sweep_operation (0=Stop, 1=Start, 2=View)
         ),
         help="""Band Scope Sweep Control.
 
         Format:
-        BSV,[SWEEP_OPERATION] - Control band scope sweep
+        BSP,[SWEEP_OPERATION] - Control band scope sweep
 
         Parameters:
         SWEEP_OPERATION : Operation (0=Stop, 1=Start, 2=View)

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -31,3 +31,14 @@ def test_scan_start_stop_registered(monkeypatch):
     # Ensure commands use adapter methods
     assert commands["scan start"]() == "KEY:S"
     assert commands["scan stop"]() == "KEY:H"
+
+
+def test_bsp_and_bsv_commands_present(monkeypatch):
+    """Battery save (BSV) and Band Scope (BSP) commands exist after build."""
+    adapter = BCD325P2Adapter()
+    monkeypatch.setattr(adapter, "send_command", lambda ser, cmd: cmd)
+
+    commands, _ = build_command_table(adapter, None)
+
+    assert "bsv" in commands
+    assert "bsp" in commands


### PR DESCRIPTION
## Summary
- correct Band Scope command key to BSP
- update regression test to check for BSP

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842075ff7088324ad16143f152f6c50