### PR TITLE
Remove obsolete BSP sweep control command

### DIFF
--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -179,6 +179,8 @@ class BCD325P2Adapter(UnidenScannerAdapter):
         try:
             cmd_obj = self.commands.get("BSP")
             if cmd_obj:
+                if cmd_obj.validator:
+                    cmd_obj.validator([freq, step, span, max_hold])
                 cmd = cmd_obj.set_format.format(
                     freq=freq, step=step, span=span, max_hold=max_hold
                 )

--- a/command_libraries/uniden/bcd325p2/freq_management_commands.py
+++ b/command_libraries/uniden/bcd325p2/freq_management_commands.py
@@ -29,22 +29,6 @@ FREQUENCY_MANAGEMENT_COMMANDS = {
         Lower limit, upper limit, step, offset, and modulation for the band
         """,
     ),
-    "BSP": ScannerCommand(
-        name="BSP",
-        requires_prg=False,
-        set_format="BSP,{sweep_operation}",
-        validator=validate_param_constraints(
-            [(int, {0, 1, 2})]  # sweep_operation (0=Stop, 1=Start, 2=View)
-        ),
-        help="""Band Scope Sweep Control.
-
-        Format:
-        BSP,[SWEEP_OPERATION] - Control band scope sweep
-
-        Parameters:
-        SWEEP_OPERATION : Operation (0=Stop, 1=Start, 2=View)
-        """,
-    ),
     "CNT": ScannerCommand(
         name="CNT",
         requires_prg=False,

--- a/command_libraries/uniden/bcd325p2/specialized_functions.py
+++ b/command_libraries/uniden/bcd325p2/specialized_functions.py
@@ -6,7 +6,10 @@ band coverage settings, and broadcast screen configuration.
 """
 
 from utilities.core.shared_utils import ScannerCommand
-from utilities.validators import validate_param_constraints
+from utilities.validators import (
+    validate_param_constraints,
+    validate_frequency_8_digit,
+)
 
 SPECIALIZED_COMMANDS = {
     "BSP": ScannerCommand(
@@ -15,7 +18,7 @@ SPECIALIZED_COMMANDS = {
         set_format="BSP,{freq},{step},{span},{max_hold}",
         validator=validate_param_constraints(
             [
-                (int, None),  # frequency
+                (str, validate_frequency_8_digit),  # frequency
                 (
                     int,
                     {

--- a/utilities/validators.py
+++ b/utilities/validators.py
@@ -138,3 +138,28 @@ def validate_binary_options(options_count):
         return value
 
     return validator
+
+
+def validate_frequency_8_digit(value):
+    """Validate an 8-digit center frequency value.
+
+    Parameters
+    ----------
+    value : str or int
+        Frequency value consisting of eight digits.
+
+    Returns
+    -------
+    str
+        The validated frequency string.
+
+    Raises
+    ------
+    ValueError
+        If the value is not an 8-digit integer.
+    """
+
+    value_str = str(value).strip()
+    if not value_str.isdigit() or len(value_str) != 8:
+        raise ValueError("Frequency must be an 8-digit value (e.g., 00125000)")
+    return value_str


### PR DESCRIPTION
## Summary
- drop duplicate BSP command from frequency management
- add validation and docs-based help text for Band Scope System Settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842325f57808324a785b740b40a5b11