### PR TITLE
Implement band sweep support

### DIFF
--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -30,3 +30,25 @@ def test_band_scope_air_command(monkeypatch):
     commands, _ = build_command_table(adapter, None)
     result = commands["band scope"]("air")
     assert result == "BSP,00125000,833,20M,0"
+
+
+def test_band_sweep_registered(monkeypatch):
+    adapter = BCD325P2Adapter()
+    monkeypatch.setattr(adapter, "sweep_band_scope", lambda ser, c, s, st: [])
+    commands, help_text = build_command_table(adapter, None)
+
+    assert "band sweep" in commands
+    assert "band sweep" in help_text
+
+
+def test_band_sweep_returns_pairs(monkeypatch):
+    adapter = BCD325P2Adapter()
+
+    def sweep_stub(ser, c, s, st):
+        return [(100.0, 0.5), (101.0, 0.6)]
+
+    monkeypatch.setattr(adapter, "sweep_band_scope", sweep_stub)
+    commands, _ = build_command_table(adapter, None)
+
+    result = commands["band sweep"]("100 2 1")
+    assert result == [(100.0, 0.5), (101.0, 0.6)]

--- a/utilities/command/help_utils.py
+++ b/utilities/command/help_utils.py
@@ -93,6 +93,7 @@ def show_help(commands, command_help, command="", adapter=None):
             "scan start",
             "scan stop",
             "band scope",
+            "band sweep",
         ],
         "Other": ["help", "switch", "exit"],
     }
@@ -108,6 +109,7 @@ def show_help(commands, command_help, command="", adapter=None):
                 "dump ",
                 "scan ",
                 "band scope ",
+                "band sweep ",
             )
         )
         for cmd in commands
@@ -133,6 +135,7 @@ def show_help(commands, command_help, command="", adapter=None):
                     or cmd.startswith("dump ")
                     or cmd.startswith("scan ")
                     or cmd.startswith("band scope")
+                    or cmd.startswith("band sweep")
                 )
             ],
             "Other": ["help", "switch", "exit"],

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -193,6 +193,27 @@ def build_command_table(adapter, ser):
             "(Not available for this scanner model)"
         )
 
+    # Band sweep
+    if hasattr(adapter, 'sweep_band_scope'):
+        logging.debug("Registering 'band sweep' command")
+
+        def band_sweep(arg=""):
+            parts = arg.split()
+            return adapter.sweep_band_scope(ser, *parts)
+
+        COMMANDS["band sweep"] = band_sweep
+        COMMAND_HELP["band sweep"] = (
+            "Sweep a range of frequencies. Usage: band sweep <center> <span> <step>"
+        )
+    else:
+        logging.debug("Registering placeholder 'band sweep' command")
+        COMMANDS["band sweep"] = lambda arg: (
+            "Command 'band sweep' not supported on this scanner model"
+        )
+        COMMAND_HELP["band sweep"] = (
+            "Sweep a range of frequencies. (Not available for this scanner model)"
+        )
+
     # Dump memory
     if hasattr(adapter, 'dump_memory_to_file'):
         logging.debug("Registering 'dump memory' command")


### PR DESCRIPTION
## Summary
- add RSSI helper and band sweep to `BCD325P2Adapter`
- register the `band sweep` command
- show `band sweep` in help output
- test new band sweep functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433b5c47c883249f69e1462cd4192a