### PR TITLE
Improve Uniden sweep and serial handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,19 @@ band sweep <center> <span> <step>
 The command returns pairs of `(frequency, rssi)` values. These readings can be
 fed into a future GUI waterfall display for visual analysis of signal activity.
 
+### Custom Search Stream
+
+For Uniden models that support the `CSC` command (e.g. BCD325P2), the CLI
+exposes a `custom search` command which streams search results directly from the
+scanner:
+
+```bash
+custom search [max_results]
+```
+
+`max_results` controls how many `CSC` lines are collected before the command
+stops.  If omitted, the default is 50 samples.
+
 ## Extending the System
 
 To support a new scanner model:

--- a/adapters/uniden/common/core.py
+++ b/adapters/uniden/common/core.py
@@ -190,8 +190,18 @@ def format_response(response, pretty=False):
         return f"RESPONSE: {response_str}"
 
 
-def send_command(self, ser, cmd):
-    """Send a command to the scanner and get the response."""
+def send_command(self, ser, cmd, delay=0.2):
+    """Send a command to the scanner and get the response.
+
+    Parameters
+    ----------
+    ser : serial.Serial
+        Connection to the scanner.
+    cmd : str or bytes
+        Command to send.
+    delay : float, optional
+        Delay passed to the lower level ``send_command`` utility.
+    """
     try:
         # Import the utility function instead of calling it directly
         from utilities.scanner.backend import (
@@ -205,7 +215,7 @@ def send_command(self, ser, cmd):
             cmd_str = str(cmd)
 
         # Use the utility function to send the command
-        response = utils_send_command(ser, cmd_str)
+        response = utils_send_command(ser, cmd_str, delay=delay)
 
         # Log the command and response
         logging.debug(

--- a/adapters/uniden/uniden_base_adapter.py
+++ b/adapters/uniden/uniden_base_adapter.py
@@ -48,8 +48,19 @@ class UnidenScannerAdapter(BaseScannerAdapter):
             return f"STATUS:{status}|MESSAGE:{msg}"
         return message
 
-    def send_command(self, ser, cmd):
-        """Send a command to the scanner and get the response."""
+    def send_command(self, ser, cmd, delay=0.2):
+        """Send a command to the scanner and get the response.
+
+        Parameters
+        ----------
+        ser : serial.Serial
+            Serial connection to the scanner.
+        cmd : str or bytes
+            Command to transmit.
+        delay : float, optional
+            Delay for the serial buffer clear before sending.  Defaults to
+            ``0.2`` seconds.
+        """
         try:
             from utilities.scanner.backend import (
                 send_command as utils_send_command,
@@ -62,7 +73,7 @@ class UnidenScannerAdapter(BaseScannerAdapter):
                 cmd_str = str(cmd)
 
             # Get the response using the utility function
-            response = utils_send_command(ser, cmd_str)
+            response = utils_send_command(ser, cmd_str, delay=delay)
 
             # Log the command and response
             logging.debug(

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -214,6 +214,22 @@ def build_command_table(adapter, ser):
             "Sweep a range of frequencies. (Not available for this scanner model)"
         )
 
+    # Custom search streaming
+    if hasattr(adapter, 'run_custom_search'):
+        logging.debug("Registering 'custom search' command")
+
+        def custom_search(arg=""):
+            try:
+                count = int(arg) if arg else 50
+            except ValueError:
+                count = 50
+            return adapter.run_custom_search(ser, max_results=count)
+
+        COMMANDS["custom search"] = custom_search
+        COMMAND_HELP["custom search"] = (
+            "Run a custom search using CSC. Usage: custom search [max_results]"
+        )
+    
     # Dump memory
     if hasattr(adapter, 'dump_memory_to_file'):
         logging.debug("Registering 'dump memory' command")

--- a/utilities/core/serial_utils.py
+++ b/utilities/core/serial_utils.py
@@ -16,15 +16,19 @@ import logging
 import time
 
 
-def clear_serial_buffer(ser):
-    """
-    Clear any accumulated data in the serial buffer before sending commands.
+def clear_serial_buffer(ser, delay=0.2):
+    """Clear any accumulated data in the serial buffer before sending commands.
 
-    Args:
-        ser: An open serial connection object
+    Parameters
+    ----------
+    ser : serial.Serial
+        Open serial connection to flush.
+    delay : float, optional
+        Seconds to pause before clearing.  Default ``0.2``.
     """
     try:
-        time.sleep(0.2)
+        if delay:
+            time.sleep(delay)
         while ser.in_waiting:
             ser.read(ser.in_waiting)
         logging.debug("Serial buffer cleared.")
@@ -68,18 +72,19 @@ def read_response(ser, timeout=1.0):
         return ""
 
 
-def send_command(ser, cmd):
-    """
-    Clear the buffer and send a command (with CR termination) to the device.
+def send_command(ser, cmd, delay=0.2):
+    """Send a command to the device and return the response.
 
-    Args:
-        ser: An open serial connection object
-        cmd: Command string to send
-
-    Returns:
-        Response from the device as a string
+    Parameters
+    ----------
+    ser : serial.Serial
+        Open connection to the device.
+    cmd : str
+        Command string to send.
+    delay : float, optional
+        Delay for :func:`clear_serial_buffer`.  Default ``0.2`` seconds.
     """
-    clear_serial_buffer(ser)
+    clear_serial_buffer(ser, delay=delay)
     full_cmd = cmd.strip() + "\r"
     try:
         ser.write(full_cmd.encode("utf-8"))

--- a/utilities/core/shared_utils.py
+++ b/utilities/core/shared_utils.py
@@ -117,20 +117,19 @@ class ScannerCommand:
         return self.parser(response) if self.parser else response
 
 
-def clear_serial_buffer(ser):
-    """
-    Clear any accumulated data in the serial buffer before sending commands.
+def clear_serial_buffer(ser, delay=0.2):
+    """Clear any accumulated data in the serial buffer before sending commands.
 
-    This helps prevent misinterpreting stale data as responses to new commands.
-
-    Parameters:
-        ser: An open serial.Serial connection to the scanner
-
-    Raises:
-        Exception: If there's an error accessing the serial port
+    Parameters
+    ----------
+    ser : serial.Serial
+        Open serial connection to the scanner.
+    delay : float, optional
+        Seconds to pause before clearing.  Default ``0.2``.
     """
     try:
-        time.sleep(0.2)
+        if delay:
+            time.sleep(delay)
         while ser.in_waiting:
             ser.read(ser.in_waiting)
         logging.debug("Serial buffer cleared.")
@@ -138,18 +137,19 @@ def clear_serial_buffer(ser):
         logging.error(f"Error clearing serial buffer: {e}")
 
 
-def send_command(ser, cmd):
-    """
-    Clear the buffer and send a command (with CR termination) to the device.
+def send_command(ser, cmd, delay=0.2):
+    """Send a command to the device and return the response.
 
-    Args:
-        ser: An open serial connection object
-        cmd: Command string to send
-
-    Returns:
-        str: Response from the device as a string
+    Parameters
+    ----------
+    ser : serial.Serial
+        Open serial connection to the device.
+    cmd : str
+        Command string to send.
+    delay : float, optional
+        Delay for :func:`clear_serial_buffer`.  Default ``0.2`` seconds.
     """
-    clear_serial_buffer(ser)
+    clear_serial_buffer(ser, delay=delay)
     full_cmd = cmd.strip() + "\r"
     try:
         ser.write(full_cmd.encode("utf-8"))

--- a/utilities/scanner/backend.py
+++ b/utilities/scanner/backend.py
@@ -5,10 +5,20 @@ import serial
 from serial.tools import list_ports
 
 
-def clear_serial_buffer(ser):
-    """Clear accumulated data in the serial buffer."""
+def clear_serial_buffer(ser, delay=0.2):
+    """Clear accumulated data in the serial buffer.
+
+    Parameters
+    ----------
+    ser : serial.Serial
+        Open serial connection to flush.
+    delay : float, optional
+        Time in seconds to pause before clearing.  Defaults to ``0.2`` to
+        maintain previous behaviour.
+    """
     try:
-        time.sleep(0.2)
+        if delay:
+            time.sleep(delay)
         while ser.in_waiting:
             ser.read(ser.in_waiting)
         logging.debug("Serial buffer cleared.")
@@ -45,9 +55,20 @@ def read_response(ser, timeout=1.0):
     return response_str
 
 
-def send_command(ser, command):
-    """Send a command to the scanner and return the response."""
-    clear_serial_buffer(ser)
+def send_command(ser, command, delay=0.2):
+    """Send a command to the scanner and return the response.
+
+    Parameters
+    ----------
+    ser : serial.Serial
+        Open serial connection to the scanner.
+    command : str or bytes
+        Command string to transmit.
+    delay : float, optional
+        Delay passed to :func:`clear_serial_buffer` before sending.  ``0.2``
+        seconds by default to retain existing behaviour.
+    """
+    clear_serial_buffer(ser, delay=delay)
     if isinstance(command, str):
         command = command.encode("ascii")
     if not command.endswith(b"\r"):

--- a/utilities/serial_utils.py
+++ b/utilities/serial_utils.py
@@ -8,10 +8,19 @@ import logging
 import time
 
 
-def clear_serial_buffer(ser):
-    """Clear accumulated data in the serial buffer before sending commands."""
+def clear_serial_buffer(ser, delay=0.2):
+    """Clear accumulated data in the serial buffer before sending commands.
+
+    Parameters
+    ----------
+    ser : serial.Serial
+        Open serial connection to flush.
+    delay : float, optional
+        Seconds to pause before clearing.  ``0.2`` by default.
+    """
     try:
-        time.sleep(0.2)
+        if delay:
+            time.sleep(delay)
         while ser.in_waiting:
             ser.read(ser.in_waiting)
         logging.debug("Serial buffer cleared.")
@@ -43,13 +52,19 @@ def read_response(ser, timeout=1.0):
         return ""
 
 
-def send_command(ser, cmd):
-    """
-    Clear the buffer and send a command (with CR termination) to the scanner.
+def send_command(ser, cmd, delay=0.2):
+    """Send a command to the scanner and return the response.
 
-    Return the response from the scanner.
+    Parameters
+    ----------
+    ser : serial.Serial
+        Open connection to the scanner.
+    cmd : str
+        Command string to send.
+    delay : float, optional
+        Delay for :func:`clear_serial_buffer`.  Default ``0.2`` seconds.
     """
-    clear_serial_buffer(ser)
+    clear_serial_buffer(ser, delay=delay)
     full_cmd = cmd.strip() + "\r"
     try:
         ser.write(full_cmd.encode("utf-8"))

--- a/utilities/shared_utils.py
+++ b/utilities/shared_utils.py
@@ -110,15 +110,19 @@ class ScannerCommand:
         return self.parser(response) if self.parser else response
 
 
-def clear_serial_buffer(ser):
-    """
-    Clear accumulated data in the serial buffer before sending commands.
+def clear_serial_buffer(ser, delay=0.2):
+    """Clear accumulated data in the serial buffer before sending commands.
 
-    This function clears the serial input and output buffers before sending
-    commands.
+    Parameters
+    ----------
+    ser : serial.Serial
+        Open serial connection to flush.
+    delay : float, optional
+        Seconds to pause before clearing.  Defaults to ``0.2``.
     """
     try:
-        time.sleep(0.2)
+        if delay:
+            time.sleep(delay)
         while ser.in_waiting:
             ser.read(ser.in_waiting)
         logging.debug("Serial buffer cleared.")


### PR DESCRIPTION
## Summary
- add `sweep_band_scope` capability to BC125AT
- implement CSC-based custom search for BCD325P2
- allow configurable delay in serial buffer clearing
- expose new CLI command `custom search`
- document custom search feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68434abc8a548324a028218070051ae9