### PR TITLE
Add custom search streaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,15 @@ band sweep <center> <span> <step>
 The command returns pairs of `(frequency, rssi)` values. These readings can be
 fed into a future GUI waterfall display for visual analysis of signal activity.
 
+### Custom Search Streaming
+
+Custom search status can be streamed using the `CSC` command. When activated the
+scanner outputs lines of the form `CSC,<RSSI>,<FRQ>,<SQL>` for each hit.
+The controller now gathers a configurable number of these records before
+stopping the stream. By default, **1024** records are collected. After the limit
+is reached the command `CSC,OFF` is issued and the final `CSC,OK` response is
+read.
+
 ## Extending the System
 
 To support a new scanner model:

--- a/adapters/uniden/bcd325p2/close_call.py
+++ b/adapters/uniden/bcd325p2/close_call.py
@@ -25,4 +25,3 @@ def jump_mode(self, ser, jump_mode, index=""):
 def jump_to_number_tag(self, ser, sys_tag="", chan_tag=""):
     """Jump to a system/channel number tag using the JNT command."""
     return self.send_command(ser, f"JNT,{sys_tag},{chan_tag}")
-

--- a/adapters/uniden/bcd325p2/custom_search.py
+++ b/adapters/uniden/bcd325p2/custom_search.py
@@ -1,7 +1,12 @@
 """Custom search streaming functions for BCD325P2."""
 
 import logging
-from utilities.core.serial_utils import send_command, wait_for_data, read_response
+
+from utilities.core.serial_utils import (
+    read_response,
+    send_command,
+    wait_for_data,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,4 +54,3 @@ def stream_custom_search(self, ser, record_count=1024):
     except Exception as e:
         logger.error(f"Error during custom search stream: {e}")
     return results
-

--- a/adapters/uniden/bcd325p2/custom_search.py
+++ b/adapters/uniden/bcd325p2/custom_search.py
@@ -1,0 +1,52 @@
+"""Custom search streaming functions for BCD325P2."""
+
+import logging
+from utilities.core.serial_utils import send_command, wait_for_data, read_response
+
+logger = logging.getLogger(__name__)
+
+
+def stream_custom_search(self, ser, record_count=1024):
+    """Stream custom search results using the CSC command.
+
+    Parameters
+    ----------
+    ser : serial.Serial
+        Serial connection to the scanner.
+    record_count : int, optional
+        Number of result lines to read before stopping the stream.
+        Defaults to 1024.
+
+    Returns
+    -------
+    list of tuple
+        Tuples of ``(rssi, freq, sql)`` collected from the scanner.
+    """
+    results = []
+    try:
+        # Start streaming
+        send_command(ser, "CSC,ON")
+        while len(results) < record_count:
+            if not wait_for_data(ser, max_wait=0.5):
+                break
+            line = read_response(ser, timeout=1.0)
+            if not line:
+                break
+            if not line.startswith("CSC,"):
+                continue
+            parts = line.split(",")
+            if len(parts) >= 4:
+                try:
+                    rssi = int(parts[1])
+                    freq = float(parts[2])
+                    sql = int(parts[3])
+                    results.append((rssi, freq, sql))
+                except ValueError:
+                    logger.debug(f"Malformed line: {line}")
+        # Stop streaming and read final OK
+        send_command(ser, "CSC,OFF")
+        read_response(ser, timeout=1.0)
+    except Exception as e:
+        logger.error(f"Error during custom search stream: {e}")
+    return results
+

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -281,7 +281,6 @@ class BCD325P2Adapter(UnidenScannerAdapter):
     start_scanning = start_scanning
     stop_scanning = stop_scanning
 
-
     def get_help(self, command):
         """Get help for a specific BCD325P2 command.
 

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -39,6 +39,7 @@ from adapters.uniden.bcd325p2.status_info import (
     read_sw_ver,
     read_window_voltage,
 )
+from adapters.uniden.bcd325p2.custom_search import stream_custom_search
 from adapters.uniden.bcd325p2.user_control import (
     send_key,
     start_scanning,
@@ -271,6 +272,9 @@ class BCD325P2Adapter(UnidenScannerAdapter):
     set_close_call = set_close_call
     jump_mode = jump_mode
     jump_to_number_tag = jump_to_number_tag
+
+    # Custom search methods
+    stream_custom_search = stream_custom_search
 
     # User control methods
     send_key = send_key

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -274,7 +274,6 @@ class BCD325P2Adapter(UnidenScannerAdapter):
     jump_to_number_tag = jump_to_number_tag
 
     # Custom search methods
-    stream_custom_search = stream_custom_search
 
     # User control methods
     send_key = send_key

--- a/adapters/uniden/common/core.py
+++ b/adapters/uniden/common/core.py
@@ -194,9 +194,7 @@ def send_command(self, ser, cmd):
     """Send a command to the scanner and get the response."""
     try:
         # Import the utility function instead of calling it directly
-        from utilities.scanner.backend import (
-            send_command as utils_send_command,
-        )
+        from utilities.scanner.backend import send_command as utils_send_command
 
         # Ensure command is a string before passing to underlying function
         if isinstance(cmd, bytes):

--- a/scanner_gui/gui/background_worker.py
+++ b/scanner_gui/gui/background_worker.py
@@ -12,7 +12,9 @@ class BackgroundWorker(QThread):
     status_received = pyqtSignal(str)
     rssi_received = pyqtSignal(float)
 
-    def __init__(self, controller, interval: int = 250, parent: Optional[object] = None):
+    def __init__(
+        self, controller, interval: int = 250, parent: Optional[object] = None
+    ):
         super().__init__(parent)
         self._controller = controller
         self._interval = interval

--- a/scanner_gui/gui/rotary_knob.py
+++ b/scanner_gui/gui/rotary_knob.py
@@ -9,6 +9,8 @@ pressing the knob.
 from PyQt6.QtCore import QSize
 from PyQt6.QtGui import QIcon
 from PyQt6.QtWidgets import QGroupBox, QHBoxLayout, QPushButton
+
+
 def build_rotary_knob(
     knob_pressed_callback=None,
     rotate_left_callback=None,

--- a/scanner_gui/gui/scanner_gui.py
+++ b/scanner_gui/gui/scanner_gui.py
@@ -156,7 +156,9 @@ class ScannerGUI(QWidget):
                 rotate_right_callback=lambda: self.send_key(">"),
             )
         )
-        left_panel.addWidget(build_audio_controls(self.vol_slider, self.sql_slider))
+        left_panel.addWidget(
+            build_audio_controls(self.vol_slider, self.sql_slider)
+        )
         left_panel.setAlignment(Qt.AlignmentFlag.AlignTop)
         outer_layout.addLayout(left_panel)
 
@@ -191,7 +193,9 @@ class ScannerGUI(QWidget):
 
         # Display
         self.display_labels = []
-        layout.addWidget(build_display_group(self.font_lcd, self.display_labels))
+        layout.addWidget(
+            build_display_group(self.font_lcd, self.display_labels)
+        )
 
         # Signal Meters
         self.rssi_bar = QProgressBar()
@@ -433,7 +437,9 @@ class ScannerGUI(QWidget):
             # new bars
             try:
                 # Find the squelch bar in the signal meters group
-                for child in self.signal_meters_group.findChildren(QProgressBar):
+                for child in self.signal_meters_group.findChildren(
+                    QProgressBar
+                ):
                     if child.objectName() == "squelchBar":
                         child.setValue(value)
                         # Save reference for future use

--- a/tests/test_adapter_close_call.py
+++ b/tests/test_adapter_close_call.py
@@ -33,7 +33,5 @@ def test_close_call_helpers_raw(monkeypatch):
     assert adapter.set_close_call(None, "0,1,2") == "CMD:CLC,0,1,2"
     assert adapter.jump_mode(None, "SCN_MODE", "5") == "CMD:JPM,SCN_MODE,5"
     assert adapter.jump_mode(None, "CC_MODE") == "CMD:JPM,CC_MODE,"
-    assert (
-        adapter.jump_to_number_tag(None, "1", "2") == "CMD:JNT,1,2"
-    )
+    assert adapter.jump_to_number_tag(None, "1", "2") == "CMD:JNT,1,2"
     assert adapter.jump_to_number_tag(None) == "CMD:JNT,,"

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -15,7 +15,9 @@ from utilities.core.command_registry import build_command_table  # noqa: E402
 
 
 def test_presets_load():
-    presets = importlib.import_module("config.band_scope_presets").BAND_SCOPE_PRESETS
+    presets = importlib.import_module(
+        "config.band_scope_presets"
+    ).BAND_SCOPE_PRESETS
     assert "air" in presets
     assert "race" in presets
     assert isinstance(presets["air"], tuple)

--- a/tests/test_close_call_methods.py
+++ b/tests/test_close_call_methods.py
@@ -17,17 +17,15 @@ def test_close_call_commands(monkeypatch):
     """Adapter methods should format Close Call commands correctly."""
     adapter = BCD325P2Adapter()
 
-    monkeypatch.setattr(
-        adapter,
-        "send_command",
-        lambda ser, cmd: f"CMD:{cmd}"
-    )
+    monkeypatch.setattr(adapter, "send_command", lambda ser, cmd: f"CMD:{cmd}")
 
     assert adapter.get_close_call(None) == "CMD:CLC"
     assert adapter.set_close_call(None, "1,0") == "CMD:CLC,1,0"
     assert adapter.set_close_call(None, [1, 0]) == "CMD:CLC,1,0"
     assert adapter.jump_mode(None, "CC_MODE") == "CMD:JPM,CC_MODE,"
-    assert adapter.jump_mode(None, "SVC_MODE", "Racing") == "CMD:JPM,SVC_MODE,Racing"
+    assert (
+        adapter.jump_mode(None, "SVC_MODE", "Racing")
+        == "CMD:JPM,SVC_MODE,Racing"
+    )
     assert adapter.jump_to_number_tag(None, "1", "2") == "CMD:JNT,1,2"
     assert adapter.jump_to_number_tag(None) == "CMD:JNT,,"
-

--- a/tests/test_custom_search.py
+++ b/tests/test_custom_search.py
@@ -14,7 +14,9 @@ from utilities.core.command_registry import build_command_table  # noqa: E402
 
 def test_custom_search_command_registered(monkeypatch):
     adapter = BCD325P2Adapter()
-    monkeypatch.setattr(adapter, "stream_custom_search", lambda ser, c=1024: [()])
+    monkeypatch.setattr(
+        adapter, "stream_custom_search", lambda ser, c=1024: [()]
+    )
 
     commands, help_text = build_command_table(adapter, None)
 
@@ -25,23 +27,19 @@ def test_custom_search_command_registered(monkeypatch):
 
 def test_stream_custom_search_collects(monkeypatch):
     adapter = BCD325P2Adapter()
-    data_lines = [
-        "CSC,10,162.0,1",
-        "CSC,11,163.0,0",
-        "CSC,OK",
-    ]
+    data_lines = ["CSC,10,162.0,1", "CSC,11,163.0,0", "CSC,OK"]
 
-    monkeypatch.setattr(
-        adapter,
-        "send_command",
-        lambda ser, cmd: "",
-    )
+    monkeypatch.setattr(adapter, "send_command", lambda ser, cmd: "")
 
     from adapters.uniden.bcd325p2 import custom_search as cs
 
     monkeypatch.setattr(cs, "send_command", lambda ser, cmd: "")
-    monkeypatch.setattr(cs, "wait_for_data", lambda ser, max_wait=0.5: bool(data_lines))
-    monkeypatch.setattr(cs, "read_response", lambda ser, timeout=1.0: data_lines.pop(0))
+    monkeypatch.setattr(
+        cs, "wait_for_data", lambda ser, max_wait=0.5: bool(data_lines)
+    )
+    monkeypatch.setattr(
+        cs, "read_response", lambda ser, timeout=1.0: data_lines.pop(0)
+    )
 
     results = adapter.stream_custom_search(None, 2)
 

--- a/tests/test_custom_search.py
+++ b/tests/test_custom_search.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import types
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+serial_stub = types.ModuleType("serial")
+serial_stub.Serial = lambda *a, **k: None
+sys.modules.setdefault("serial", serial_stub)
+
+from adapters.uniden.bcd325p2_adapter import BCD325P2Adapter  # noqa: E402
+from utilities.core.command_registry import build_command_table  # noqa: E402
+
+
+def test_custom_search_command_registered(monkeypatch):
+    adapter = BCD325P2Adapter()
+    monkeypatch.setattr(adapter, "stream_custom_search", lambda ser, c=1024: [()])
+
+    commands, help_text = build_command_table(adapter, None)
+
+    assert "custom search" in commands
+    assert "custom search" in help_text
+    assert commands["custom search"]("5") == [()]
+
+
+def test_stream_custom_search_collects(monkeypatch):
+    adapter = BCD325P2Adapter()
+    data_lines = [
+        "CSC,10,162.0,1",
+        "CSC,11,163.0,0",
+        "CSC,OK",
+    ]
+
+    monkeypatch.setattr(
+        adapter,
+        "send_command",
+        lambda ser, cmd: "",
+    )
+
+    from adapters.uniden.bcd325p2 import custom_search as cs
+
+    monkeypatch.setattr(cs, "send_command", lambda ser, cmd: "")
+    monkeypatch.setattr(cs, "wait_for_data", lambda ser, max_wait=0.5: bool(data_lines))
+    monkeypatch.setattr(cs, "read_response", lambda ser, timeout=1.0: data_lines.pop(0))
+
+    results = adapter.stream_custom_search(None, 2)
+
+    assert results == [(10, 162.0, 1), (11, 163.0, 0)]

--- a/tests/test_scanner_manager.py
+++ b/tests/test_scanner_manager.py
@@ -82,11 +82,14 @@ def test_connect_to_scanner_unknown_uniden_model(monkeypatch):
             self.is_open = False
 
     monkeypatch.setattr(manager.serial, "Serial", lambda *a, **k: DummySerial())
-    monkeypatch.setattr(manager, "find_all_scanner_ports", lambda: [("COM1", "BC999XLT")])
+    monkeypatch.setattr(
+        manager, "find_all_scanner_ports", lambda: [("COM1", "BC999XLT")]
+    )
 
     ser, adapter, commands, help_text = manager.connect_to_scanner("1")
     assert isinstance(adapter, GenericUnidenAdapter)
     assert isinstance(ser, DummySerial)
+
 
 def test_generic_uniden_read_volume(monkeypatch):
     """read_volume should parse numeric volume from response."""
@@ -95,6 +98,7 @@ def test_generic_uniden_read_volume(monkeypatch):
     adapter = GenericUnidenAdapter(machine_mode=True)
     monkeypatch.setattr(adapter, "send_command", lambda ser, cmd: b"VOL,7")
     assert adapter.read_volume(None) == 7
+
 
 def test_generic_uniden_write_volume(monkeypatch):
     """write_volume should return True when 'OK' is received."""
@@ -105,6 +109,7 @@ def test_generic_uniden_write_volume(monkeypatch):
     monkeypatch.setattr(adapter, "send_command", lambda ser, cmd: b"OK")
     assert adapter.write_volume(None, 5) is True
 
+
 def test_generic_uniden_read_squelch(monkeypatch):
     """read_squelch should parse numeric squelch from response."""
     from adapters.uniden.generic_adapter import GenericUnidenAdapter
@@ -112,6 +117,7 @@ def test_generic_uniden_read_squelch(monkeypatch):
     adapter = GenericUnidenAdapter(machine_mode=True)
     monkeypatch.setattr(adapter, "send_command", lambda ser, cmd: b"SQL,3")
     assert adapter.read_squelch(None) == 3
+
 
 def test_generic_uniden_write_squelch(monkeypatch):
     """write_squelch should return True when 'OK' is received."""

--- a/utilities/command/help_utils.py
+++ b/utilities/command/help_utils.py
@@ -94,6 +94,7 @@ def show_help(commands, command_help, command="", adapter=None):
             "scan stop",
             "band scope",
             "band sweep",
+            "custom search",
         ],
         "Other": ["help", "switch", "exit"],
     }
@@ -110,6 +111,7 @@ def show_help(commands, command_help, command="", adapter=None):
                 "scan ",
                 "band scope ",
                 "band sweep ",
+                "custom search ",
             )
         )
         for cmd in commands
@@ -136,6 +138,7 @@ def show_help(commands, command_help, command="", adapter=None):
                     or cmd.startswith("scan ")
                     or cmd.startswith("band scope")
                     or cmd.startswith("band sweep")
+                    or cmd.startswith("custom search")
                 )
             ],
             "Other": ["help", "switch", "exit"],

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -203,7 +203,8 @@ def build_command_table(adapter, ser):
 
         COMMANDS["band sweep"] = band_sweep
         COMMAND_HELP["band sweep"] = (
-            "Sweep a range of frequencies. Usage: band sweep <center> <span> <step>"
+            "Sweep a range of frequencies. Usage: band sweep "
+            "<center> <span> <step>"
         )
     else:
         logging.debug("Registering placeholder 'band sweep' command")
@@ -211,7 +212,8 @@ def build_command_table(adapter, ser):
             "Command 'band sweep' not supported on this scanner model"
         )
         COMMAND_HELP["band sweep"] = (
-            "Sweep a range of frequencies. (Not available for this scanner model)"
+            "Sweep a range of frequencies. (Not available for this "
+            "scanner model)"
         )
 
     # Custom search stream
@@ -232,7 +234,8 @@ def build_command_table(adapter, ser):
             "Command 'custom search' not supported on this scanner model"
         )
         COMMAND_HELP["custom search"] = (
-            "Stream custom search results. (Not available for this scanner model)"
+            "Stream custom search results. (Not available for this scanner "
+            "model)"
         )
 
     # Dump memory

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -214,6 +214,27 @@ def build_command_table(adapter, ser):
             "Sweep a range of frequencies. (Not available for this scanner model)"
         )
 
+    # Custom search stream
+    if hasattr(adapter, 'stream_custom_search'):
+        logging.debug("Registering 'custom search' command")
+
+        def custom_search(arg=""):
+            count = int(arg) if arg else 1024
+            return adapter.stream_custom_search(ser, count)
+
+        COMMANDS["custom search"] = custom_search
+        COMMAND_HELP["custom search"] = (
+            "Stream custom search results. Usage: custom search [record_count]"
+        )
+    else:
+        logging.debug("Registering placeholder 'custom search' command")
+        COMMANDS["custom search"] = lambda arg="": (
+            "Command 'custom search' not supported on this scanner model"
+        )
+        COMMAND_HELP["custom search"] = (
+            "Stream custom search results. (Not available for this scanner model)"
+        )
+
     # Dump memory
     if hasattr(adapter, 'dump_memory_to_file'):
         logging.debug("Registering 'dump memory' command")

--- a/utilities/scanner/backend.py
+++ b/utilities/scanner/backend.py
@@ -57,7 +57,9 @@ def send_command(ser, command):
     return read_response(ser)
 
 
-def find_all_scanner_ports(baudrate=115200, timeout=0.5, max_retries=2, skip_ports=None):
+def find_all_scanner_ports(
+    baudrate=115200, timeout=0.5, max_retries=2, skip_ports=None
+):
     """Scan available serial ports for connected scanners."""
     if skip_ports is None:
         skip_ports = []
@@ -67,7 +69,9 @@ def find_all_scanner_ports(baudrate=115200, timeout=0.5, max_retries=2, skip_por
         ports = list_ports.comports()
         logging.info(f"Available ports: {len(ports)}")
         for port_info in ports:
-            logging.info(f"Available port: {port_info.device} - {port_info.description}")
+            logging.info(
+                f"Available port: {port_info.device} - {port_info.description}"
+            )
         for port_info in ports:
             port = port_info.device
             if port in skip_ports:
@@ -75,7 +79,9 @@ def find_all_scanner_ports(baudrate=115200, timeout=0.5, max_retries=2, skip_por
                 continue
             logging.info(f"Trying port: {port} ({port_info.description})")
             try:
-                with serial.Serial(port, baudrate, timeout=timeout, write_timeout=0.5) as ser:
+                with serial.Serial(
+                    port, baudrate, timeout=timeout, write_timeout=0.5
+                ) as ser:
                     time.sleep(0.1)
                     logging.info(f"Sending MDL to {port}")
                     ser.write(b"MDL\r")


### PR DESCRIPTION
## Summary
- implement CSC streaming for the BCD325P2
- expose new `custom search` command in the command registry and help system
- document default record count behavior in README
- test streaming and registry integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684357f23c6c8324ad90bf3311d272a3