### PR TITLE
Revise band scope commands and add RSSI graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,13 @@ python -m scanner_gui.main
 
 Use the interface to select a serial port and control the scanner.
 
-### Band Sweep Command
+### Custom Search Command
 
-The CLI also provides a `band sweep` command to scan a range of frequencies and
+The CLI provides a `custom search` command to sweep a range of frequencies and
 collect RSSI readings:
 
 ```bash
-band sweep <center> <span> <step>
+custom search <center> <span> <step>
 ```
 
 * `<center>` – center frequency of the sweep. Values may include a unit
@@ -138,9 +138,9 @@ band sweep <center> <span> <step>
 The command returns pairs of `(frequency, rssi)` values. These readings can be
 fed into a future GUI waterfall display for visual analysis of signal activity.
 
-### Custom Search Streaming
+### Band Scope Streaming
 
-Custom search status can be streamed using the `CSC` command. When activated the
+Band scope status can be streamed using the `CSC` command. When activated the
 scanner outputs lines of the form `CSC,<RSSI>,<FRQ>,<SQL>` for each hit.
 The controller now gathers a configurable number of these records before
 stopping the stream. By default, **1024** records are collected. After the limit

--- a/adapters/uniden/bcd325p2/custom_search.py
+++ b/adapters/uniden/bcd325p2/custom_search.py
@@ -29,8 +29,8 @@ def stream_custom_search(self, ser, record_count=1024):
     """
     results = []
     try:
-        # Start streaming
-        send_command(ser, "CSC,ON")
+        # Start streaming without the usual buffer flush delay
+        send_command(ser, "CSC,ON", delay=0)
         while len(results) < record_count:
             if not wait_for_data(ser, max_wait=0.5):
                 break
@@ -49,7 +49,7 @@ def stream_custom_search(self, ser, record_count=1024):
                 except ValueError:
                     logger.debug(f"Malformed line: {line}")
         # Stop streaming and read final OK
-        send_command(ser, "CSC,OFF")
+        send_command(ser, "CSC,OFF", delay=0)
         read_response(ser, timeout=1.0)
     except Exception as e:
         logger.error(f"Error during custom search stream: {e}")

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -274,6 +274,7 @@ class BCD325P2Adapter(UnidenScannerAdapter):
     jump_to_number_tag = jump_to_number_tag
 
     # Custom search methods
+    stream_custom_search = stream_custom_search
 
     # User control methods
     send_key = send_key

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -24,26 +24,26 @@ def test_presets_load():
     assert len(presets["air"]) == 4
 
 
-def test_band_scope_air_command(monkeypatch):
+def test_band_sweep_air_command(monkeypatch):
     adapter = BCD325P2Adapter()
     adapter.in_program_mode = True
     monkeypatch.setattr(adapter, "send_command", lambda ser, cmd: cmd)
 
     commands, _ = build_command_table(adapter, None)
-    result = commands["band scope"]("air")
+    result = commands["band sweep"]("air")
     assert result == "BSP,00125000,833,20M,0"
 
 
 def test_band_sweep_registered(monkeypatch):
     adapter = BCD325P2Adapter()
-    monkeypatch.setattr(adapter, "sweep_band_scope", lambda ser, c, s, st: [])
+    monkeypatch.setattr(adapter, "configure_band_scope", lambda ser, *a: "")
     commands, help_text = build_command_table(adapter, None)
 
     assert "band sweep" in commands
     assert "band sweep" in help_text
 
 
-def test_band_sweep_returns_pairs(monkeypatch):
+def test_custom_search_returns_pairs(monkeypatch):
     adapter = BCD325P2Adapter()
 
     def sweep_stub(ser, c, s, st):
@@ -52,11 +52,11 @@ def test_band_sweep_returns_pairs(monkeypatch):
     monkeypatch.setattr(adapter, "sweep_band_scope", sweep_stub)
     commands, _ = build_command_table(adapter, None)
 
-    result = commands["band sweep"]("100 2 1")
+    result = commands["custom search"]("100 2 1")
     assert result == [(100.0, 0.5), (101.0, 0.6)]
 
 
-def test_band_sweep_parses_units(monkeypatch):
+def test_custom_search_parses_units(monkeypatch):
     adapter = BCD325P2Adapter()
 
     monkeypatch.setattr(adapter, "write_frequency", lambda ser, f: None)

--- a/tests/test_custom_search.py
+++ b/tests/test_custom_search.py
@@ -12,7 +12,7 @@ from adapters.uniden.bcd325p2_adapter import BCD325P2Adapter  # noqa: E402
 from utilities.core.command_registry import build_command_table  # noqa: E402
 
 
-def test_custom_search_command_registered(monkeypatch):
+def test_band_scope_command_registered(monkeypatch):
     adapter = BCD325P2Adapter()
     monkeypatch.setattr(
         adapter, "stream_custom_search", lambda ser, c=1024: [()]
@@ -20,20 +20,20 @@ def test_custom_search_command_registered(monkeypatch):
 
     commands, help_text = build_command_table(adapter, None)
 
-    assert "custom search" in commands
-    assert "custom search" in help_text
-    assert commands["custom search"]("5") == [()]
+    assert "band scope" in commands
+    assert "band scope" in help_text
+    assert commands["band scope"]("5") == [()]
 
 
-def test_stream_custom_search_collects(monkeypatch):
+def test_band_scope_collects(monkeypatch):
     adapter = BCD325P2Adapter()
     data_lines = ["CSC,10,162.0,1", "CSC,11,163.0,0", "CSC,OK"]
 
-    monkeypatch.setattr(adapter, "send_command", lambda ser, cmd: "")
+    monkeypatch.setattr(adapter, "send_command", lambda ser, cmd, delay=0.2: "")
 
     from adapters.uniden.bcd325p2 import custom_search as cs
 
-    monkeypatch.setattr(cs, "send_command", lambda ser, cmd: "")
+    monkeypatch.setattr(cs, "send_command", lambda ser, cmd, delay=0.2: "")
     monkeypatch.setattr(
         cs, "wait_for_data", lambda ser, max_wait=0.5: bool(data_lines)
     )

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utilities.graph_utils import render_rssi_graph
+
+
+def test_render_rssi_graph_levels():
+    data = [(0, x / 15.0) for x in range(16)]
+    output = render_rssi_graph(data)
+    lines = output.splitlines()
+    assert len(lines) == 2
+    assert len(lines[0]) == 16
+    assert len(lines[1]) == 16
+
+

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -30,6 +30,7 @@ from utilities.core.serial_utils import (
 )
 from utilities.io.readline_setup import initialize_readline
 from utilities.log_utils import configure_logging, get_logger
+from utilities.graph_utils import render_rssi_graph
 
 # Only export specific names (instead of using __all__ = ['*'])
 __all__ = [
@@ -53,4 +54,5 @@ __all__ = [
     "read_response",
     "send_command",
     "wait_for_data",
+    "render_rssi_graph",
 ]

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -161,15 +161,36 @@ def build_command_table(adapter, ser):
             "(Not available for this scanner model)"
         )
 
-    # Band scope configuration
-    if hasattr(adapter, 'configure_band_scope'):
+    # Band scope (CSC streaming)
+    if hasattr(adapter, 'stream_custom_search'):
         logging.debug("Registering 'band scope' command")
 
         def band_scope(arg=""):
+            count = int(arg) if arg else 1024
+            return adapter.stream_custom_search(ser, count)
+
+        COMMANDS["band scope"] = band_scope
+        COMMAND_HELP["band scope"] = (
+            "Stream band scope data. Usage: band scope [record_count]"
+        )
+    else:
+        logging.debug("Registering placeholder 'band scope' command")
+        COMMANDS["band scope"] = lambda arg="": (
+            "Command 'band scope' not supported on this scanner model"
+        )
+        COMMAND_HELP["band scope"] = (
+            "Stream band scope data. (Not available for this scanner model)"
+        )
+
+    # Band sweep presets
+    if hasattr(adapter, 'configure_band_scope'):
+        logging.debug("Registering 'band sweep' command")
+
+        def band_sweep(arg=""):
             parts = arg.split()
             return adapter.configure_band_scope(ser, *parts)
 
-        COMMANDS["band scope"] = band_scope
+        COMMANDS["band sweep"] = band_sweep
 
         try:
             from config.band_scope_presets import BAND_SCOPE_PRESETS
@@ -179,32 +200,9 @@ def build_command_table(adapter, ser):
         except ImportError:
             preset_help = ""
 
-        COMMAND_HELP["band scope"] = (
-            "Configure band scope settings. Usage: band scope <preset> or "
-            "band scope <freq> <step> <span> <max_hold>." + preset_help
-        )
-    else:
-        logging.debug("Registering placeholder 'band scope' command")
-        COMMANDS["band scope"] = lambda arg: (
-            "Command 'band scope' not supported on this scanner model"
-        )
-        COMMAND_HELP["band scope"] = (
-            "Configure band scope settings. "
-            "(Not available for this scanner model)"
-        )
-
-    # Band sweep
-    if hasattr(adapter, 'sweep_band_scope'):
-        logging.debug("Registering 'band sweep' command")
-
-        def band_sweep(arg=""):
-            parts = arg.split()
-            return adapter.sweep_band_scope(ser, *parts)
-
-        COMMANDS["band sweep"] = band_sweep
         COMMAND_HELP["band sweep"] = (
-            "Sweep a range of frequencies. Usage: band sweep "
-            "<center> <span> <step>"
+            "Sweep using a preset. Usage: band sweep <preset> or "
+            "band sweep <freq> <step> <span> <max_hold>." + preset_help
         )
     else:
         logging.debug("Registering placeholder 'band sweep' command")
@@ -212,30 +210,30 @@ def build_command_table(adapter, ser):
             "Command 'band sweep' not supported on this scanner model"
         )
         COMMAND_HELP["band sweep"] = (
-            "Sweep a range of frequencies. (Not available for this "
-            "scanner model)"
+            "Sweep using a preset. (Not available for this scanner model)"
         )
 
-    # Custom search stream
-    if hasattr(adapter, 'stream_custom_search'):
+    # Custom search (frequency sweep)
+    if hasattr(adapter, 'sweep_band_scope'):
         logging.debug("Registering 'custom search' command")
 
         def custom_search(arg=""):
-            count = int(arg) if arg else 1024
-            return adapter.stream_custom_search(ser, count)
+            parts = arg.split()
+            return adapter.sweep_band_scope(ser, *parts)
 
         COMMANDS["custom search"] = custom_search
         COMMAND_HELP["custom search"] = (
-            "Stream custom search results. Usage: custom search [record_count]"
+            "Perform a custom frequency sweep. Usage: custom search "
+            "<center> <span> <step>"
         )
     else:
         logging.debug("Registering placeholder 'custom search' command")
-        COMMANDS["custom search"] = lambda arg="": (
+        COMMANDS["custom search"] = lambda arg: (
             "Command 'custom search' not supported on this scanner model"
         )
         COMMAND_HELP["custom search"] = (
-            "Stream custom search results. (Not available for this scanner "
-            "model)"
+            "Perform a custom frequency sweep. (Not available for this "
+            "scanner model)"
         )
 
     # Dump memory

--- a/utilities/core/serial_utils.py
+++ b/utilities/core/serial_utils.py
@@ -16,15 +16,19 @@ import logging
 import time
 
 
-def clear_serial_buffer(ser):
-    """
-    Clear any accumulated data in the serial buffer before sending commands.
+def clear_serial_buffer(ser, delay=0.2):
+    """Clear any accumulated data in the serial buffer before sending commands.
 
-    Args:
-        ser: An open serial connection object
+    Parameters
+    ----------
+    ser : serial.Serial
+        Open serial connection object.
+    delay : float, optional
+        Time to wait before flushing the buffer. Defaults to ``0.2`` seconds.
     """
     try:
-        time.sleep(0.2)
+        if delay:
+            time.sleep(delay)
         while ser.in_waiting:
             ser.read(ser.in_waiting)
         logging.debug("Serial buffer cleared.")
@@ -68,18 +72,24 @@ def read_response(ser, timeout=1.0):
         return ""
 
 
-def send_command(ser, cmd):
-    """
-    Clear the buffer and send a command (with CR termination) to the device.
+def send_command(ser, cmd, delay=0.2):
+    """Clear the buffer and send a command (with CR termination) to the device.
 
-    Args:
-        ser: An open serial connection object
-        cmd: Command string to send
+    Parameters
+    ----------
+    ser : serial.Serial
+        Open serial connection object.
+    cmd : str
+        Command string to send.
+    delay : float, optional
+        Delay passed to :func:`clear_serial_buffer`. Defaults to ``0.2`` seconds.
 
-    Returns:
-        Response from the device as a string
+    Returns
+    -------
+    str
+        Response from the device as a string.
     """
-    clear_serial_buffer(ser)
+    clear_serial_buffer(ser, delay)
     full_cmd = cmd.strip() + "\r"
     try:
         ser.write(full_cmd.encode("utf-8"))

--- a/utilities/core/shared_utils.py
+++ b/utilities/core/shared_utils.py
@@ -117,20 +117,19 @@ class ScannerCommand:
         return self.parser(response) if self.parser else response
 
 
-def clear_serial_buffer(ser):
-    """
-    Clear any accumulated data in the serial buffer before sending commands.
+def clear_serial_buffer(ser, delay=0.2):
+    """Clear accumulated data in the serial buffer before sending commands.
 
-    This helps prevent misinterpreting stale data as responses to new commands.
-
-    Parameters:
-        ser: An open serial.Serial connection to the scanner
-
-    Raises:
-        Exception: If there's an error accessing the serial port
+    Parameters
+    ----------
+    ser : serial.Serial
+        Open serial connection to the scanner.
+    delay : float, optional
+        Time to wait before flushing the buffer. Defaults to ``0.2`` seconds.
     """
     try:
-        time.sleep(0.2)
+        if delay:
+            time.sleep(delay)
         while ser.in_waiting:
             ser.read(ser.in_waiting)
         logging.debug("Serial buffer cleared.")
@@ -138,18 +137,24 @@ def clear_serial_buffer(ser):
         logging.error(f"Error clearing serial buffer: {e}")
 
 
-def send_command(ser, cmd):
-    """
-    Clear the buffer and send a command (with CR termination) to the device.
+def send_command(ser, cmd, delay=0.2):
+    """Clear the buffer and send a command (with CR termination) to the device.
 
-    Args:
-        ser: An open serial connection object
-        cmd: Command string to send
+    Parameters
+    ----------
+    ser : serial.Serial
+        Open serial connection object.
+    cmd : str
+        Command string to send.
+    delay : float, optional
+        Delay passed to :func:`clear_serial_buffer`. Defaults to ``0.2`` seconds.
 
-    Returns:
-        str: Response from the device as a string
+    Returns
+    -------
+    str
+        Response from the device as a string.
     """
-    clear_serial_buffer(ser)
+    clear_serial_buffer(ser, delay)
     full_cmd = cmd.strip() + "\r"
     try:
         ser.write(full_cmd.encode("utf-8"))

--- a/utilities/graph_utils.py
+++ b/utilities/graph_utils.py
@@ -1,0 +1,37 @@
+"""Utilities for visualizing RSSI sweep data."""
+
+BLOCKS = [" ", "\u2581", "\u2582", "\u2583", "\u2584", "\u2585", "\u2586", "\u2587", "\u2588"]
+
+
+def render_rssi_graph(pairs):
+    """Return a two-line unicode graph from ``(freq, rssi)`` pairs.
+
+    Parameters
+    ----------
+    pairs : list of tuple
+        Sequence of ``(frequency, rssi)`` tuples where RSSI is normalized
+        between ``0`` and ``1``.
+
+    Returns
+    -------
+    str
+        Two lines of characters representing relative signal strength.
+    """
+    top = []
+    bottom = []
+    for _, rssi in pairs:
+        if rssi is None:
+            level = 0
+        else:
+            level = max(0, min(16, int(round(rssi * 16))))
+        if level <= 8:
+            bottom_idx = level
+            top_idx = 0
+        else:
+            bottom_idx = 8
+            top_idx = level - 8
+        bottom.append(BLOCKS[bottom_idx])
+        top.append(BLOCKS[top_idx])
+    return "".join(top) + "\n" + "".join(bottom)
+
+

--- a/utilities/scanner/backend.py
+++ b/utilities/scanner/backend.py
@@ -5,10 +5,19 @@ import serial
 from serial.tools import list_ports
 
 
-def clear_serial_buffer(ser):
-    """Clear accumulated data in the serial buffer."""
+def clear_serial_buffer(ser, delay=0.2):
+    """Clear accumulated data in the serial buffer.
+
+    Parameters
+    ----------
+    ser : serial.Serial
+        Open serial connection to the scanner.
+    delay : float, optional
+        Time to wait before flushing the buffer. Defaults to ``0.2`` seconds.
+    """
     try:
-        time.sleep(0.2)
+        if delay:
+            time.sleep(delay)
         while ser.in_waiting:
             ser.read(ser.in_waiting)
         logging.debug("Serial buffer cleared.")
@@ -45,9 +54,20 @@ def read_response(ser, timeout=1.0):
     return response_str
 
 
-def send_command(ser, command):
-    """Send a command to the scanner and return the response."""
-    clear_serial_buffer(ser)
+def send_command(ser, command, delay=0.2):
+    """Send a command to the scanner and return the response.
+
+    Parameters
+    ----------
+    ser : serial.Serial
+        Open serial connection to the scanner.
+    command : str
+        Command string to send.
+    delay : float, optional
+        Delay passed to :func:`clear_serial_buffer` before sending the command.
+        Defaults to ``0.2`` seconds.
+    """
+    clear_serial_buffer(ser, delay)
     if isinstance(command, str):
         command = command.encode("ascii")
     if not command.endswith(b"\r"):

--- a/utilities/serial_utils.py
+++ b/utilities/serial_utils.py
@@ -8,10 +8,19 @@ import logging
 import time
 
 
-def clear_serial_buffer(ser):
-    """Clear accumulated data in the serial buffer before sending commands."""
+def clear_serial_buffer(ser, delay=0.2):
+    """Clear accumulated data in the serial buffer before sending commands.
+
+    Parameters
+    ----------
+    ser : serial.Serial
+        Open serial connection object.
+    delay : float, optional
+        Time to wait before flushing the buffer. Defaults to ``0.2`` seconds.
+    """
     try:
-        time.sleep(0.2)
+        if delay:
+            time.sleep(delay)
         while ser.in_waiting:
             ser.read(ser.in_waiting)
         logging.debug("Serial buffer cleared.")
@@ -43,13 +52,24 @@ def read_response(ser, timeout=1.0):
         return ""
 
 
-def send_command(ser, cmd):
-    """
-    Clear the buffer and send a command (with CR termination) to the scanner.
+def send_command(ser, cmd, delay=0.2):
+    """Clear the buffer and send a command (with CR termination) to the scanner.
 
-    Return the response from the scanner.
+    Parameters
+    ----------
+    ser : serial.Serial
+        Open serial connection object.
+    cmd : str
+        Command string to send.
+    delay : float, optional
+        Delay passed to :func:`clear_serial_buffer`. Defaults to ``0.2`` seconds.
+
+    Returns
+    -------
+    str
+        Response from the scanner.
     """
-    clear_serial_buffer(ser)
+    clear_serial_buffer(ser, delay)
     full_cmd = cmd.strip() + "\r"
     try:
         ser.write(full_cmd.encode("utf-8"))

--- a/utilities/shared_utils.py
+++ b/utilities/shared_utils.py
@@ -110,15 +110,19 @@ class ScannerCommand:
         return self.parser(response) if self.parser else response
 
 
-def clear_serial_buffer(ser):
-    """
-    Clear accumulated data in the serial buffer before sending commands.
+def clear_serial_buffer(ser, delay=0.2):
+    """Clear accumulated data in the serial buffer before sending commands.
 
-    This function clears the serial input and output buffers before sending
-    commands.
+    Parameters
+    ----------
+    ser : serial.Serial
+        Serial connection to clear.
+    delay : float, optional
+        Time to wait before flushing the buffer. Defaults to ``0.2`` seconds.
     """
     try:
-        time.sleep(0.2)
+        if delay:
+            time.sleep(delay)
         while ser.in_waiting:
             ser.read(ser.in_waiting)
         logging.debug("Serial buffer cleared.")


### PR DESCRIPTION
## Summary
- swap command names for band scope, band sweep and custom search
- allow skipping delays in `clear_serial_buffer`
- bypass delay when streaming CSC data
- add `render_rssi_graph` helper
- document updated commands
- adjust tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684365b0e17083248725c7271eb1f804