### PR TITLE
Add band scope graph output

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ The controller now gathers a configurable number of these records before
 stopping the stream. By default, **1024** records are collected. After the limit
 is reached the command `CSC,OFF` is issued and the final `CSC,OK` response is
 read.
+When called through the CLI's `band scope` command these readings are displayed
+as a simple two-line graph to give quick visual feedback.
 
 ## Extending the System
 

--- a/tests/test_custom_search.py
+++ b/tests/test_custom_search.py
@@ -15,14 +15,19 @@ from utilities.core.command_registry import build_command_table  # noqa: E402
 def test_band_scope_command_registered(monkeypatch):
     adapter = BCD325P2Adapter()
     monkeypatch.setattr(
-        adapter, "stream_custom_search", lambda ser, c=1024: [()]
+        adapter,
+        "stream_custom_search",
+        lambda ser, c=1024: [(0, 100.0, 0)] * int(c),
     )
 
     commands, help_text = build_command_table(adapter, None)
 
     assert "band scope" in commands
     assert "band scope" in help_text
-    assert commands["band scope"]("5") == [()]
+    output = commands["band scope"]("5")
+    lines = output.splitlines()
+    assert len(lines) == 2
+    assert len(lines[0]) == 5
 
 
 def test_band_scope_collects(monkeypatch):

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -6,6 +6,8 @@ This module builds the command table from scanner adapter capabilities.
 
 import logging
 
+from utilities.graph_utils import render_rssi_graph
+
 
 def build_command_table(adapter, ser):
     """
@@ -167,7 +169,12 @@ def build_command_table(adapter, ser):
 
         def band_scope(arg=""):
             count = int(arg) if arg else 1024
-            return adapter.stream_custom_search(ser, count)
+            results = adapter.stream_custom_search(ser, count)
+            pairs = [
+                (freq, rssi / 1023.0 if rssi is not None else None)
+                for rssi, freq, _ in results
+            ]
+            return render_rssi_graph(pairs)
 
         COMMANDS["band scope"] = band_scope
         COMMAND_HELP["band scope"] = (


### PR DESCRIPTION
## Summary
- hook `render_rssi_graph` into band scope command
- update docs about new band scope output
- adjust tests for the graph output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436c533f2c83248a872a522f4d5c91