### PR TITLE
Reduce serial command delay

### DIFF
--- a/tests/test_custom_search.py
+++ b/tests/test_custom_search.py
@@ -34,11 +34,11 @@ def test_band_scope_collects(monkeypatch):
     adapter = BCD325P2Adapter()
     data_lines = ["CSC,10,162.0,1", "CSC,11,163.0,0", "CSC,OK"]
 
-    monkeypatch.setattr(adapter, "send_command", lambda ser, cmd, delay=0.2: "")
+    monkeypatch.setattr(adapter, "send_command", lambda ser, cmd, delay=0: "")
 
     from adapters.uniden.bcd325p2 import custom_search as cs
 
-    monkeypatch.setattr(cs, "send_command", lambda ser, cmd, delay=0.2: "")
+    monkeypatch.setattr(cs, "send_command", lambda ser, cmd, delay=0: "")
     monkeypatch.setattr(
         cs, "wait_for_data", lambda ser, max_wait=0.5: bool(data_lines)
     )

--- a/utilities/core/serial_utils.py
+++ b/utilities/core/serial_utils.py
@@ -16,7 +16,7 @@ import logging
 import time
 
 
-def clear_serial_buffer(ser, delay=0.2):
+def clear_serial_buffer(ser, delay=0.0):
     """Clear any accumulated data in the serial buffer before sending commands.
 
     Parameters
@@ -24,7 +24,7 @@ def clear_serial_buffer(ser, delay=0.2):
     ser : serial.Serial
         Open serial connection object.
     delay : float, optional
-        Time to wait before flushing the buffer. Defaults to ``0.2`` seconds.
+        Time to wait before flushing the buffer. Defaults to ``0`` seconds.
     """
     try:
         if delay:
@@ -72,7 +72,7 @@ def read_response(ser, timeout=1.0):
         return ""
 
 
-def send_command(ser, cmd, delay=0.2):
+def send_command(ser, cmd, delay=0.0):
     """Clear the buffer and send a command (with CR termination) to the device.
 
     Parameters
@@ -82,7 +82,7 @@ def send_command(ser, cmd, delay=0.2):
     cmd : str
         Command string to send.
     delay : float, optional
-        Delay passed to :func:`clear_serial_buffer`. Defaults to ``0.2`` seconds.
+        Delay passed to :func:`clear_serial_buffer`. Defaults to ``0`` seconds.
 
     Returns
     -------

--- a/utilities/core/shared_utils.py
+++ b/utilities/core/shared_utils.py
@@ -117,7 +117,7 @@ class ScannerCommand:
         return self.parser(response) if self.parser else response
 
 
-def clear_serial_buffer(ser, delay=0.2):
+def clear_serial_buffer(ser, delay=0.0):
     """Clear accumulated data in the serial buffer before sending commands.
 
     Parameters
@@ -125,7 +125,7 @@ def clear_serial_buffer(ser, delay=0.2):
     ser : serial.Serial
         Open serial connection to the scanner.
     delay : float, optional
-        Time to wait before flushing the buffer. Defaults to ``0.2`` seconds.
+        Time to wait before flushing the buffer. Defaults to ``0`` seconds.
     """
     try:
         if delay:
@@ -137,7 +137,7 @@ def clear_serial_buffer(ser, delay=0.2):
         logging.error(f"Error clearing serial buffer: {e}")
 
 
-def send_command(ser, cmd, delay=0.2):
+def send_command(ser, cmd, delay=0.0):
     """Clear the buffer and send a command (with CR termination) to the device.
 
     Parameters
@@ -147,7 +147,7 @@ def send_command(ser, cmd, delay=0.2):
     cmd : str
         Command string to send.
     delay : float, optional
-        Delay passed to :func:`clear_serial_buffer`. Defaults to ``0.2`` seconds.
+        Delay passed to :func:`clear_serial_buffer`. Defaults to ``0`` seconds.
 
     Returns
     -------

--- a/utilities/scanner/backend.py
+++ b/utilities/scanner/backend.py
@@ -5,7 +5,7 @@ import serial
 from serial.tools import list_ports
 
 
-def clear_serial_buffer(ser, delay=0.2):
+def clear_serial_buffer(ser, delay=0.0):
     """Clear accumulated data in the serial buffer.
 
     Parameters
@@ -13,7 +13,7 @@ def clear_serial_buffer(ser, delay=0.2):
     ser : serial.Serial
         Open serial connection to the scanner.
     delay : float, optional
-        Time to wait before flushing the buffer. Defaults to ``0.2`` seconds.
+        Time to wait before flushing the buffer. Defaults to ``0`` seconds.
     """
     try:
         if delay:
@@ -54,7 +54,7 @@ def read_response(ser, timeout=1.0):
     return response_str
 
 
-def send_command(ser, command, delay=0.2):
+def send_command(ser, command, delay=0.0):
     """Send a command to the scanner and return the response.
 
     Parameters
@@ -65,7 +65,7 @@ def send_command(ser, command, delay=0.2):
         Command string to send.
     delay : float, optional
         Delay passed to :func:`clear_serial_buffer` before sending the command.
-        Defaults to ``0.2`` seconds.
+        Defaults to ``0`` seconds.
     """
     clear_serial_buffer(ser, delay)
     if isinstance(command, str):

--- a/utilities/serial_utils.py
+++ b/utilities/serial_utils.py
@@ -8,7 +8,7 @@ import logging
 import time
 
 
-def clear_serial_buffer(ser, delay=0.2):
+def clear_serial_buffer(ser, delay=0.0):
     """Clear accumulated data in the serial buffer before sending commands.
 
     Parameters
@@ -16,7 +16,7 @@ def clear_serial_buffer(ser, delay=0.2):
     ser : serial.Serial
         Open serial connection object.
     delay : float, optional
-        Time to wait before flushing the buffer. Defaults to ``0.2`` seconds.
+        Time to wait before flushing the buffer. Defaults to ``0`` seconds.
     """
     try:
         if delay:
@@ -52,7 +52,7 @@ def read_response(ser, timeout=1.0):
         return ""
 
 
-def send_command(ser, cmd, delay=0.2):
+def send_command(ser, cmd, delay=0.0):
     """Clear the buffer and send a command (with CR termination) to the scanner.
 
     Parameters
@@ -62,7 +62,7 @@ def send_command(ser, cmd, delay=0.2):
     cmd : str
         Command string to send.
     delay : float, optional
-        Delay passed to :func:`clear_serial_buffer`. Defaults to ``0.2`` seconds.
+        Delay passed to :func:`clear_serial_buffer`. Defaults to ``0`` seconds.
 
     Returns
     -------

--- a/utilities/shared_utils.py
+++ b/utilities/shared_utils.py
@@ -110,7 +110,7 @@ class ScannerCommand:
         return self.parser(response) if self.parser else response
 
 
-def clear_serial_buffer(ser, delay=0.2):
+def clear_serial_buffer(ser, delay=0.0):
     """Clear accumulated data in the serial buffer before sending commands.
 
     Parameters
@@ -118,7 +118,7 @@ def clear_serial_buffer(ser, delay=0.2):
     ser : serial.Serial
         Serial connection to clear.
     delay : float, optional
-        Time to wait before flushing the buffer. Defaults to ``0.2`` seconds.
+        Time to wait before flushing the buffer. Defaults to ``0`` seconds.
     """
     try:
         if delay:


### PR DESCRIPTION
## Summary
- default `delay` args in all serial helper functions to 0
- update docstrings accordingly
- adjust custom search tests for new default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684374ebdfa0832483e9738e26306880