### PR TITLE
Implement band scope waterfall renderer

### DIFF
--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -12,6 +12,7 @@ sys.modules.setdefault("serial", serial_stub)
 import importlib
 from adapters.uniden.bcd325p2_adapter import BCD325P2Adapter  # noqa: E402
 from utilities.core.command_registry import build_command_table  # noqa: E402
+from utilities.graph_utils import render_band_scope_waterfall
 
 
 def test_presets_load():
@@ -63,3 +64,18 @@ def test_custom_search_parses_units(monkeypatch):
     monkeypatch.setattr(adapter, "read_rssi", lambda ser: 0)
     result = adapter.sweep_band_scope(None, "144M", "2M", "500k")
     assert result[0][0] == 143.0
+
+
+def test_render_band_scope_waterfall_wrap():
+    pairs = [
+        (100.0, 0.0),
+        (101.0, 0.5),
+        (102.0, 1.0),
+        (100.0, 1.0),
+        (101.0, 0.5),
+        (102.0, 0.0),
+    ]
+    output = render_band_scope_waterfall(pairs, width=3)
+    lines = output.splitlines()
+    assert len(lines) == 2
+    assert all(len(line) == 3 for line in lines)

--- a/tests/test_custom_search.py
+++ b/tests/test_custom_search.py
@@ -17,17 +17,17 @@ def test_band_scope_command_registered(monkeypatch):
     monkeypatch.setattr(
         adapter,
         "stream_custom_search",
-        lambda ser, c=1024: [(0, 100.0, 0)] * int(c),
+        lambda ser, c=1024: [(0, 100.0 + i % 5, 0) for i in range(int(c))],
     )
 
     commands, help_text = build_command_table(adapter, None)
 
     assert "band scope" in commands
     assert "band scope" in help_text
-    output = commands["band scope"]("5")
+    output = commands["band scope"]("10 5")
     lines = output.splitlines()
     assert len(lines) == 2
-    assert len(lines[0]) == 5
+    assert all(len(line) == 5 for line in lines)
 
 
 def test_band_scope_collects(monkeypatch):

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -30,7 +30,7 @@ from utilities.core.serial_utils import (
 )
 from utilities.io.readline_setup import initialize_readline
 from utilities.log_utils import configure_logging, get_logger
-from utilities.graph_utils import render_rssi_graph
+from utilities.graph_utils import render_rssi_graph, render_band_scope_waterfall
 
 # Only export specific names (instead of using __all__ = ['*'])
 __all__ = [
@@ -55,4 +55,5 @@ __all__ = [
     "send_command",
     "wait_for_data",
     "render_rssi_graph",
+    "render_band_scope_waterfall",
 ]

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -6,7 +6,10 @@ This module builds the command table from scanner adapter capabilities.
 
 import logging
 
-from utilities.graph_utils import render_rssi_graph
+from utilities.graph_utils import (
+    render_rssi_graph,
+    render_band_scope_waterfall,
+)
 
 
 def build_command_table(adapter, ser):
@@ -168,17 +171,19 @@ def build_command_table(adapter, ser):
         logging.debug("Registering 'band scope' command")
 
         def band_scope(arg=""):
-            count = int(arg) if arg else 1024
+            parts = arg.split()
+            count = int(parts[0]) if parts else 1024
+            width = int(parts[1]) if len(parts) > 1 else 64
             results = adapter.stream_custom_search(ser, count)
             pairs = [
                 (freq, rssi / 1023.0 if rssi is not None else None)
                 for rssi, freq, _ in results
             ]
-            return render_rssi_graph(pairs)
+            return render_band_scope_waterfall(pairs, width)
 
         COMMANDS["band scope"] = band_scope
         COMMAND_HELP["band scope"] = (
-            "Stream band scope data. Usage: band scope [record_count]"
+            "Stream band scope data. Usage: band scope [record_count] [width]"
         )
     else:
         logging.debug("Registering placeholder 'band scope' command")


### PR DESCRIPTION
## Summary
- add `render_band_scope_waterfall` in `graph_utils`
- export the new helper from `utilities`
- update band scope command to use the waterfall renderer
- adjust tests for new behaviour and add wrapping test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684377642d7c83249e122b68b078f6d1