### PR TITLE
Auto width for band scope

### DIFF
--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -79,3 +79,23 @@ def test_render_band_scope_waterfall_wrap():
     lines = output.splitlines()
     assert len(lines) == 2
     assert all(len(line) == 3 for line in lines)
+
+
+def test_band_scope_auto_width(monkeypatch):
+    adapter = BCD325P2Adapter()
+
+    monkeypatch.setattr(adapter, "write_frequency", lambda ser, f: None)
+    monkeypatch.setattr(adapter, "read_rssi", lambda ser: 0)
+    adapter.sweep_band_scope(None, "146M", "2M", "0.5M")
+    assert adapter.band_scope_width == 5
+
+    monkeypatch.setattr(
+        adapter,
+        "stream_custom_search",
+        lambda ser, c=5: [(0, 145.0 + 0.5 * i, 0) for i in range(c)],
+    )
+
+    commands, _ = build_command_table(adapter, None)
+    output = commands["band scope"]("5")
+    lines = output.splitlines()
+    assert all(len(line) == 5 for line in lines)

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -173,7 +173,10 @@ def build_command_table(adapter, ser):
         def band_scope(arg=""):
             parts = arg.split()
             count = int(parts[0]) if parts else 1024
-            width = int(parts[1]) if len(parts) > 1 else 64
+            if len(parts) > 1:
+                width = int(parts[1])
+            else:
+                width = getattr(adapter, "band_scope_width", 64) or 64
             results = adapter.stream_custom_search(ser, count)
             pairs = [
                 (freq, rssi / 1023.0 if rssi is not None else None)


### PR DESCRIPTION
## Summary
- track band sweep configuration and derive bin count
- use stored width for `band scope` command
- test that custom sweep sets width and band scope auto-selects it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684374194970832482fcbbfb0d5706fb