### PR TITLE
Add Close Call logging utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ read.
 When called through the CLI's `band scope` command these readings are displayed
 as a simple two-line graph to give quick visual feedback.
 
+### Close Call Logging
+
+The utility function `record_close_calls` allows continuous logging of Close Call
+hits to an SQLite database. Use the CLI commands `log close calls` or
+`log close calls lockout` and provide a band name such as `air` or `frs`. Each
+hit is saved with timestamp, frequency, tone (if available) and RSSI level. When
+the `lockout` variant is used the frequency is also added to the scanner's
+temporary lockout list via the `LOF` command.
+
 ## Extending the System
 
 To support a new scanner model:

--- a/config/close_call_bands.py
+++ b/config/close_call_bands.py
@@ -1,0 +1,15 @@
+"""Mapping of band names to Close Call band masks."""
+
+CLOSE_CALL_BANDS = {
+    "air": "0010000",
+    "race": "0000010",
+    "frs": "0000010",
+    "marine": "0001000",
+    "railroad": "0001000",
+    "ham2m": "0001000",
+    "ham70cm": "0000010",
+    "weather": "0001000",
+    "cb": "1000000",
+    "public_safety": "0001000",
+    "mil_air": "0000010",
+}

--- a/tests/test_close_call_logger.py
+++ b/tests/test_close_call_logger.py
@@ -1,0 +1,84 @@
+"""Tests for close_call_logger.record_close_calls."""
+
+import os
+import sys
+import types
+import sqlite3
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+serial_stub = types.ModuleType("serial")
+serial_stub.Serial = lambda *a, **k: None
+serial_tools_stub = types.ModuleType("serial.tools")
+list_ports_stub = types.ModuleType("serial.tools.list_ports")
+list_ports_stub.comports = lambda *a, **k: []
+serial_tools_stub.list_ports = list_ports_stub
+serial_stub.tools = serial_tools_stub
+sys.modules.setdefault("serial.tools", serial_tools_stub)
+sys.modules.setdefault("serial.tools.list_ports", list_ports_stub)
+sys.modules.setdefault("serial", serial_stub)
+
+from utilities.scanner.close_call_logger import record_close_calls  # noqa: E402
+from config.close_call_bands import CLOSE_CALL_BANDS  # noqa: E402
+
+
+class DummyAdapter:
+    def __init__(self):
+        self.mask = None
+        self.lof_sent = None
+
+    def set_close_call(self, ser, params):
+        self.mask = params
+
+    def jump_mode(self, ser, mode):
+        self.jumped = mode
+
+    def read_frequency(self, ser):
+        raise NotImplementedError
+
+    def read_rssi(self, ser):
+        return 0.5
+
+    def send_command(self, ser, cmd):
+        self.lof_sent = cmd
+
+
+def test_band_mask_and_db_write(tmp_path, monkeypatch):
+    adapter = DummyAdapter()
+    db = tmp_path / "cc.db"
+
+    calls = [130.0]
+
+    def freq_stub(ser):
+        if calls:
+            return calls.pop(0)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(adapter, "read_frequency", freq_stub)
+
+    record_close_calls(adapter, None, "air", db_path=str(db))
+
+    assert adapter.mask == CLOSE_CALL_BANDS["air"]
+
+    conn = sqlite3.connect(db)
+    count = conn.execute("SELECT COUNT(*) FROM close_calls").fetchone()[0]
+    conn.close()
+    assert count == 1
+
+
+def test_lockout_sends_lof(tmp_path, monkeypatch):
+    adapter = DummyAdapter()
+    db = tmp_path / "cc.db"
+
+    calls = [162.5]
+
+    def freq_stub(ser):
+        if calls:
+            return calls.pop(0)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(adapter, "read_frequency", freq_stub)
+
+    record_close_calls(adapter, None, "air", db_path=str(db), lockout=True)
+
+    assert adapter.lof_sent == "LOF,162.5"

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -32,6 +32,11 @@ from utilities.io.readline_setup import initialize_readline
 from utilities.log_utils import configure_logging, get_logger
 from utilities.graph_utils import render_rssi_graph, render_band_scope_waterfall
 
+try:
+    from utilities.scanner.close_call_logger import record_close_calls
+except Exception:  # pragma: no cover - optional import for tests
+    record_close_calls = None
+
 # Only export specific names (instead of using __all__ = ['*'])
 __all__ = [
     "configure_logging",
@@ -56,4 +61,5 @@ __all__ = [
     "wait_for_data",
     "render_rssi_graph",
     "render_band_scope_waterfall",
+    "record_close_calls",
 ]

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -266,6 +266,30 @@ def build_command_table(adapter, ser):
             "(Not available for this scanner model)"
         )
 
+    # Close Call logging
+    try:
+        from utilities.scanner.close_call_logger import record_close_calls
+
+        def _log_close_calls(arg="", lockout=False):
+            band = arg.strip() or "air"
+            return record_close_calls(adapter, ser, band, lockout=lockout)
+
+        COMMANDS["log close calls"] = lambda arg="": _log_close_calls(arg)
+        COMMAND_HELP[
+            "log close calls"
+        ] = "Log Close Call hits. Usage: log close calls <band>"
+
+        COMMANDS["log close calls lockout"] = lambda arg="": _log_close_calls(
+            arg, True
+        )
+        COMMAND_HELP[
+            "log close calls lockout"
+        ] = (
+            "Log Close Call hits and lock them out. Usage: log close calls lockout <band>"
+        )
+    except Exception:
+        logging.debug("Close Call logging utilities unavailable")
+
     # Scan start/stop
     if hasattr(adapter, 'start_scanning'):
         logging.debug("Registering 'scan start' command")

--- a/utilities/scanner/close_call_logger.py
+++ b/utilities/scanner/close_call_logger.py
@@ -54,11 +54,19 @@ def record_close_calls(adapter, ser, band, *, db_path="close_calls.db", lockout=
                     "INSERT INTO close_calls VALUES (?, ?, ?, ?)",
                     (ts, freq, tone, rssi),
                 )
-                conn.commit()
+                record_count += 1
+
+                # Commit after every 10 records
+                if record_count >= 10:
+                    conn.commit()
+                    record_count = 0
 
                 if lockout and freq is not None:
                     adapter.send_command(ser, f"LOF,{freq}")
             except KeyboardInterrupt:
                 break
+        # Commit any remaining records
+        if record_count > 0:
+            conn.commit()
     finally:
         conn.close()

--- a/utilities/scanner/close_call_logger.py
+++ b/utilities/scanner/close_call_logger.py
@@ -1,0 +1,64 @@
+"""Close Call logging utilities."""
+
+import logging
+import sqlite3
+import time
+from typing import Optional
+
+from config.close_call_bands import CLOSE_CALL_BANDS
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_float(value: object) -> Optional[float]:
+    """Return a float from ``value`` if possible."""
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        digits = "".join(ch for ch in str(value) if ch.isdigit() or ch == ".")
+        return float(digits) if digits else None
+    except Exception:
+        return None
+
+
+def record_close_calls(adapter, ser, band, *, db_path="close_calls.db", lockout=False):
+    """Monitor Close Call hits within a chosen band and log each hit."""
+    band_key = str(band).lower()
+    if band_key not in CLOSE_CALL_BANDS:
+        raise KeyError(f"Unknown band: {band}")
+
+    mask = CLOSE_CALL_BANDS[band_key]
+    adapter.set_close_call(ser, mask)
+    adapter.jump_mode(ser, "CC_MODE")
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS close_calls (timestamp REAL, frequency REAL, tone TEXT, rssi REAL)"
+    )
+    conn.commit()
+
+    try:
+        while True:
+            try:
+                freq_raw = adapter.read_frequency(ser)
+                freq = _parse_float(freq_raw)
+                tone = ""
+                if hasattr(adapter, "read_tone"):
+                    tone = adapter.read_tone(ser)
+                rssi_raw = adapter.read_rssi(ser)
+                rssi = _parse_float(rssi_raw)
+
+                ts = time.time()
+                cur.execute(
+                    "INSERT INTO close_calls VALUES (?, ?, ?, ?)",
+                    (ts, freq, tone, rssi),
+                )
+                conn.commit()
+
+                if lockout and freq is not None:
+                    adapter.send_command(ser, f"LOF,{freq}")
+            except KeyboardInterrupt:
+                break
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
- map band names to 7-digit Close Call masks
- implement `record_close_calls` to log hits and optional lockout
- expose `record_close_calls` in utilities
- register `log close calls` commands
- document Close Call logging
- test Close Call logging behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68439f2fe15083249fa3538c503d2ff0