### PR TITLE
Fix uninitialized variable in close call logger

### DIFF
--- a/utilities/scanner/close_call_logger.py
+++ b/utilities/scanner/close_call_logger.py
@@ -21,7 +21,9 @@ def _parse_float(value: object) -> Optional[float]:
         return None
 
 
-def record_close_calls(adapter, ser, band, *, db_path="close_calls.db", lockout=False):
+def record_close_calls(
+    adapter, ser, band, *, db_path="close_calls.db", lockout=False
+):
     """Monitor Close Call hits within a chosen band and log each hit."""
     band_key = str(band).lower()
     if band_key not in CLOSE_CALL_BANDS:
@@ -38,6 +40,7 @@ def record_close_calls(adapter, ser, band, *, db_path="close_calls.db", lockout=
     )
     conn.commit()
 
+    record_count = 0
     try:
         while True:
             try:


### PR DESCRIPTION
## Summary
- fix uninitialized `record_count` in `record_close_calls`

## Testing
- `black utilities/scanner/close_call_logger.py --line-length 80`
- `isort utilities/scanner/close_call_logger.py --profile black`
- `flake8 utilities/scanner/close_call_logger.py` *(fails: command not found)*
- `pytest tests/test_close_call_logger.py::test_band_mask_and_db_write -q`
- `pytest tests/test_close_call_logger.py::test_lockout_sends_lof -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843a51732bc83249170325c2ebf81a9