### PR TITLE
Refactor command registry handlers to accept connection args

### DIFF
--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -31,7 +31,7 @@ def test_band_sweep_air_command(monkeypatch):
     monkeypatch.setattr(adapter, "send_command", lambda ser, cmd: cmd)
 
     commands, _ = build_command_table(adapter, None)
-    result = commands["band sweep"]("air")
+    result = commands["band sweep"](None, adapter, "air")
     assert result == "BSP,00125000,833,20M,0"
 
 
@@ -53,7 +53,7 @@ def test_custom_search_returns_pairs(monkeypatch):
     monkeypatch.setattr(adapter, "sweep_band_scope", sweep_stub)
     commands, _ = build_command_table(adapter, None)
 
-    result = commands["custom search"]("100 2 1")
+    result = commands["custom search"](None, adapter, "100 2 1")
     assert result == [(100.0, 0.5), (101.0, 0.6)]
 
 
@@ -96,6 +96,6 @@ def test_band_scope_auto_width(monkeypatch):
     )
 
     commands, _ = build_command_table(adapter, None)
-    output = commands["band scope"]("5")
+    output = commands["band scope"](None, adapter, "5")
     lines = output.splitlines()
     assert all(len(line) == 5 for line in lines)

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -29,8 +29,8 @@ def test_scan_start_stop_registered(monkeypatch):
     assert help_text["scan stop"] == "Stop scanner scanning process."
 
     # Ensure commands use adapter methods
-    assert commands["scan start"]() == "KEY:S"
-    assert commands["scan stop"]() == "KEY:H"
+    assert commands["scan start"](None, adapter) == "KEY:S"
+    assert commands["scan stop"](None, adapter) == "KEY:H"
 
 
 def test_bsp_and_bsv_commands_present(monkeypatch):

--- a/tests/test_custom_search.py
+++ b/tests/test_custom_search.py
@@ -24,7 +24,7 @@ def test_band_scope_command_registered(monkeypatch):
 
     assert "band scope" in commands
     assert "band scope" in help_text
-    output = commands["band scope"]("10 5")
+    output = commands["band scope"](None, adapter, "10 5")
     lines = output.splitlines()
     assert len(lines) == 2
     assert all(len(line) == 5 for line in lines)

--- a/utilities/scanner/manager.py
+++ b/utilities/scanner/manager.py
@@ -7,6 +7,7 @@ This module contains functions for managing scanner connections and switching.
 import logging
 
 import serial
+from functools import partial
 
 from utilities.core.command_registry import build_command_table
 from utilities.scanner.backend import find_all_scanner_ports
@@ -351,6 +352,7 @@ def connect_to_scanner(
 
         # Build command table
         commands, command_help = build_command_table(adapter, ser)
+        commands = {name: partial(func, ser, adapter) for name, func in commands.items()}
 
         # If we need to merge with existing commands
         if existing_commands is not None and existing_command_help is not None:


### PR DESCRIPTION
## Summary
- update `build_command_table` so command handlers require `(ser, adapter)`
- bind connection parameters inside `ConnectionManager` and scanner manager
- adjust tests for new handler signatures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ec82b2388324b23e8e87dbe719f1