### PR TITLE
Add multi-connection support to command loop

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,12 +11,12 @@ import argparse
 import logging
 
 from utilities.command.loop import main_loop
+from utilities.scanner.manager import detect_and_connect_scanner, connection_manager
 
 # Local application/relative imports
 from utilities.core.shared_utils import diagnose_connection_issues
 from utilities.io.timeout_utils import ScannerTimeoutError
 from utilities.log_utils import configure_logging
-from utilities.scanner.manager import detect_and_connect_scanner
 
 # ------------------------------------------------------------------------------
 # LOGGING SETUP
@@ -75,7 +75,7 @@ def main():
             # Just start command loop with no scanner connected
             logger.info("Starting command loop without scanner in machine mode")
             print("STATUS:INFO|MESSAGE:Ready_for_commands")
-            main_loop(None, None, {}, {}, machine_mode)
+            main_loop(connection_manager, None, None, {}, {}, machine_mode)
         else:
             # For normal mode, continue with automatic scanner detection
             # Detect and connect to scanner
@@ -102,7 +102,7 @@ def main():
                 return
 
             # Start interactive command loop
-            main_loop(adapter, ser, commands, command_help, machine_mode)
+            main_loop(connection_manager, adapter, ser, commands, command_help, machine_mode)
 
     except ScannerTimeoutError:
         if machine_mode:

--- a/tests/test_machine_mode.py
+++ b/tests/test_machine_mode.py
@@ -48,7 +48,7 @@ def test_main_machine_mode_enabled(capsys, monkeypatch):
     well as evidence that the loop was invoked.
     """
 
-    def dummy_loop(adapter, ser, commands, command_help, machine_mode):
+    def dummy_loop(cm, adapter, ser, commands, command_help, machine_mode):
         print("MAIN_LOOP_CALLED")
 
     monkeypatch.setattr(main, "main_loop", dummy_loop)
@@ -81,7 +81,8 @@ def test_main_loop_exit_machine_mode(capsys, monkeypatch):
         "utilities.command.loop.initialize_readline", lambda c: None
     )
 
-    original_main_loop(None, None, {}, {}, True)
+    from utilities.scanner.manager import connection_manager
+    original_main_loop(connection_manager, None, None, {}, {}, True)
 
     out = capsys.readouterr().out
     assert "STATUS:INFO|MESSAGE:Scanner_ready" in out

--- a/utilities/command/parser.py
+++ b/utilities/command/parser.py
@@ -9,13 +9,16 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def parse_command(input_str, commands):
+def parse_command(input_str, commands, connection_manager=None):
     """
     Parse user input into a command and its arguments.
 
     Parameters:
         input_str (str): User input string.
         commands (dict): Dictionary of available commands.
+        connection_manager (ConnectionManager, optional):
+            Manager providing the active connection's command set. Defaults
+            to ``None``.
 
     Returns:
         tuple: Parsed command and arguments.
@@ -35,12 +38,22 @@ def parse_command(input_str, commands):
 
     for i in range(min(3, len(parts)), 0, -1):
         candidate = " ".join(parts[:i]).lower()
+        # Check global commands first
         if candidate in commands:
             logger.debug(
                 f"Matched command: '{candidate}' with "
                 f"args: '{' '.join(parts[i:])}'"
             )
             return candidate, " ".join(parts[i:])
+        # If not found, check commands for the active connection
+        if connection_manager:
+            conn = connection_manager.get()
+            if conn and candidate in conn[2]:
+                logger.debug(
+                    f"Matched connection command: '{candidate}' with "
+                    f"args: '{' '.join(parts[i:])}'"
+                )
+                return candidate, " ".join(parts[i:])
 
     logger.debug(
         f"No matching command found for '{parts[0]}', treating as unknown "


### PR DESCRIPTION
## Summary
- extend command parser to look up commands via ConnectionManager
- refactor command loop to manage multiple connections
- expose ConnectionManager in main entry point
- update machine mode tests for new function signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ee7db1c48324a1841664e1536ac1