### PR TITLE
Add multi-controller support to GUI

### DIFF
--- a/scanner_gui/__init__.py
+++ b/scanner_gui/__init__.py
@@ -6,7 +6,7 @@ scanner models, including the Uniden BC125AT.
 """
 
 # Import the controller directly
-from .controller import ScannerController
+from .controller import ScannerController, controller_registry
 
 # Import ScannerGUI using the safe getter function
 from .main import get_scanner_gui
@@ -14,4 +14,4 @@ from .main import get_scanner_gui
 # Get the ScannerGUI class safely
 ScannerGUI = get_scanner_gui()
 
-__all__ = ['ScannerGUI', 'ScannerController']
+__all__ = ['ScannerGUI', 'ScannerController', 'controller_registry']


### PR DESCRIPTION
## Summary
- implement `ControllerRegistry` for `ScannerController` objects
- export the registry from `scanner_gui`
- update GUI to manage connections with the registry
- spawn a background worker per active controller
- add Disconnect button and handle closing windows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f121f90c83249e1d9ecad09a7b02