### PR TITLE
Update help display for connection management commands

### DIFF
--- a/utilities/command/help_utils.py
+++ b/utilities/command/help_utils.py
@@ -96,7 +96,15 @@ def show_help(commands, command_help, command="", adapter=None):
             "band sweep",
             "custom search",
         ],
-        "Other": ["help", "switch", "exit"],
+        "Other": [
+            "help",
+            "list",
+            "connect",
+            "use",
+            "close",
+            "switch",
+            "exit",
+        ],
     }
 
     # Check if any high-level commands exist in COMMANDS
@@ -141,7 +149,11 @@ def show_help(commands, command_help, command="", adapter=None):
                     or cmd.startswith("custom search")
                 )
             ],
-            "Other": ["help", "switch", "exit"],
+            "Other": [
+                cmd
+                for cmd in sorted(commands)
+                if cmd in standard_commands["Other"]
+            ],
         }
 
         # Ensure Controlling Scanner commands are always displayed if they exist


### PR DESCRIPTION
## Summary
- list connection management commands in standard "Other" help category
- show those commands in the interactive help display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684508bba1e08324bcf882d2c365d1ff