### PR TITLE
Handle lockout read timeout

### DIFF
--- a/adapters/uniden/bc125at/channel.py
+++ b/adapters/uniden/bc125at/channel.py
@@ -4,6 +4,8 @@ Channel-related functions for the BC125AT scanner.
 Contains functions for reading and writing channel information.
 """
 
+import time
+
 from adapters.uniden.common.core import ensure_str
 
 
@@ -69,25 +71,39 @@ def write_channel_info(
         return self.feedback(False, f"Error writing channel info: {e}")
 
 
-def read_global_lockout(self, ser):
+def read_global_lockout(self, ser, timeout=5):
     """Read global lockout frequencies.
 
-    Args:
-        ser: Serial connection to the scanner.
+    Parameters
+    ----------
+    ser : serial.Serial
+        Serial connection to the scanner.
+    timeout : float, optional
+        Maximum time in seconds to wait for the ``GLF,-1`` sentinel.
 
-    Returns:
-        str: Lockout frequency data or error message.
+    Returns
+    -------
+    str
+        Lockout frequency data or an error message if timed out.
     """
     try:
         self.enter_programming_mode(ser)
         results = []
+        start = time.time()
         while True:
-            response = self.send_command(ser, "GLF")
-            response_str = ensure_str(response)
+            if time.time() - start > timeout:
+                self.exit_programming_mode(ser)
+                return self.feedback(
+                    False,
+                    f"Timed out waiting for GLF,-1 after {timeout} seconds",
+                )
 
-            if response_str.strip() == "GLF,-1":
+            response = self.send_command(ser, "GLF")
+            response_str = ensure_str(response).strip()
+
+            if response_str == "GLF,-1":
                 break
-            results.append(response_str.strip())
+            results.append(response_str)
         self.exit_programming_mode(ser)
         return self.feedback(True, "\n".join(results))
     except Exception as e:

--- a/tests/test_read_global_lockout.py
+++ b/tests/test_read_global_lockout.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import types
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+serial_stub = types.ModuleType("serial")
+serial_stub.Serial = lambda *a, **k: None
+serial_tools_stub = types.ModuleType("serial.tools")
+list_ports_stub = types.ModuleType("serial.tools.list_ports")
+list_ports_stub.comports = lambda *a, **k: []
+serial_tools_stub.list_ports = list_ports_stub
+serial_stub.tools = serial_tools_stub
+sys.modules.setdefault("serial", serial_stub)
+sys.modules.setdefault("serial.tools", serial_tools_stub)
+sys.modules.setdefault("serial.tools.list_ports", list_ports_stub)
+
+from adapters.uniden.bcd325p2_adapter import BCD325P2Adapter  # noqa: E402
+from adapters.uniden.bc125at_adapter import BC125ATAdapter  # noqa: E402
+
+
+def _prepare_adapter(adapter, monkeypatch, responses):
+    monkeypatch.setattr(adapter, "enter_programming_mode", lambda ser: None)
+    monkeypatch.setattr(adapter, "exit_programming_mode", lambda ser: None)
+    monkeypatch.setattr(
+        adapter,
+        "send_command",
+        lambda ser, cmd: responses.pop(0) if responses else b"GLF,100",
+    )
+
+
+def test_read_global_lockout_timeout(monkeypatch):
+    adapter = BCD325P2Adapter()
+    responses = [b"GLF,100", b"GLF,200"]  # No sentinel
+    _prepare_adapter(adapter, monkeypatch, responses)
+    result = adapter.read_global_lockout(None, timeout=0.01)
+    assert "Timed out" in result
+
+
+def test_read_global_lockout_success(monkeypatch):
+    adapter = BC125ATAdapter()
+    responses = [b"GLF,1", b"GLF,2", b"GLF,-1"]
+    _prepare_adapter(adapter, monkeypatch, responses)
+    result = adapter.read_global_lockout(None)
+    assert "GLF,1" in result and "GLF,2" in result


### PR DESCRIPTION
## Summary
- add a timeout to read_global_lockout functions
- document new behaviour in docstrings
- test timeout logic for both adapters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486aeee6e08324950c0520f9f70b99