### PR TITLE
Add limits for close call logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,15 @@ hit is saved with timestamp, frequency, tone (if available) and RSSI level. When
 the `lockout` variant is used the frequency is also added to the scanner's
 temporary lockout list via the `LOF` command.
 
+The logger normally runs indefinitely. To capture a limited number of hits or
+stop after a set time, pass ``max_records`` or ``max_time`` to
+``record_close_calls``:
+
+```python
+from utilities.scanner.close_call_logger import record_close_calls
+record_close_calls(adapter, ser, "air", max_time=10)
+```
+
 ### Using Multiple Scanners
 
 The controller can maintain more than one active connection. The CLI now


### PR DESCRIPTION
## Summary
- extend `record_close_calls` with `max_records` and `max_time`
- ensure DB connection closes when exiting early
- document running the logger for a limited time
- test that logging can stop after a set number of records or time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486c843e0c83249f27e22dd684d28e