### PR TITLE
Expand CLI help topics

### DIFF
--- a/utilities/command/help_topics.py
+++ b/utilities/command/help_topics.py
@@ -90,6 +90,51 @@ Methods:
   jump_mode            - jump to a search or Close Call mode
   jump_to_number_tag   - jump to a system/channel number tag
 """,
+    "connect": """
+Connect Command Usage:
+----------------------
+The 'connect' command opens a new connection to a detected scanner.
+
+Syntax: connect <scanner_id>
+
+First run the 'scan' command to list available scanners. Use the
+corresponding ID number with 'connect' to establish the connection.
+""",
+    "list": """
+List Command Usage:
+-------------------
+The 'list' command shows all open scanner connections. The current
+active connection is marked with an asterisk.
+
+Syntax: list
+""",
+    "use": """
+Use Command Usage:
+------------------
+The 'use' command selects which open connection is active.
+
+Syntax: use <connection_id>
+
+Run 'list' to see available IDs, then use the desired ID with this
+command to make it active.
+""",
+    "close": """
+Close Command Usage:
+--------------------
+The 'close' command terminates an existing connection.
+
+Syntax: close <connection_id>
+
+After closing the active connection you may open another or exit.
+""",
+    "switch": """
+Switch Command Usage:
+---------------------
+The 'switch' command closes the current connection and immediately
+opens a new one using the provided scanner ID.
+
+Syntax: switch <scanner_id>
+""",
 }
 
 

--- a/utilities/command/help_utils.py
+++ b/utilities/command/help_utils.py
@@ -24,16 +24,21 @@ def show_help(commands, command_help, command="", adapter=None):
         command (str): Specific command to display help for.
         adapter (object): Scanner adapter instance.
     """
-    # Display help for a specific command
+    # Display help for a specific command or topic
     if command:
         cmd = command.strip().lower()
+
         if cmd in command_help:
             print(f"\nHelp for '{cmd}':\n  {command_help[cmd]}")
 
-            extended_help = get_extended_help(cmd)
-            if extended_help:
-                print(f"\n{extended_help}")
+        extended_help = get_extended_help(cmd)
+        if extended_help:
+            if cmd not in command_help:
+                print(f"\nHelp for '{cmd}':")
+            print(f"\n{extended_help}")
+            return
 
+        if cmd in command_help:
             return
 
         if adapter and hasattr(adapter, "get_help"):

--- a/utilities/scanner/manager.py
+++ b/utilities/scanner/manager.py
@@ -276,6 +276,7 @@ def detect_and_connect_scanner(machine_mode=False):
             )
         else:
             print(f"Connected to {port} ({scanner_model}) [ID {conn_id}]")
+            print("Type 'help' for available commands.")
 
         return conn_id, ser, adapter, commands, command_help
 


### PR DESCRIPTION
## Summary
- provide detailed help for `connect`, `list`, `use`, `close` and `switch`
- show topic descriptions even if they aren't regular commands
- print a helpful hint after connecting to a scanner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848705ce52883248707a716ce352fec