### PR TITLE
Add band scope sweep for BC125AT

### DIFF
--- a/adapters/uniden/bc125at/status_info.py
+++ b/adapters/uniden/bc125at/status_info.py
@@ -56,11 +56,10 @@ def read_rssi(self, ser):
 
         parts = response_str.split(",")
         if len(parts) == 3:
-            rssi_value = round(int(parts[1]) / 1023.0, 3)
-            return self.feedback(True, f"RSSI: {rssi_value}")
-        return self.feedback(False, f"Unexpected PWR response: {response_str}")
-    except Exception as e:
-        return self.feedback(False, f"Error reading RSSI: {e}")
+            return round(int(parts[1]) / 1023.0, 3)
+    except Exception:
+        pass
+    return None
 
 
 def read_battery_voltage(self, ser):

--- a/tests/test_bc125at_band_scope.py
+++ b/tests/test_bc125at_band_scope.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import types
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+serial_stub = types.ModuleType("serial")
+serial_stub.Serial = lambda *a, **k: None
+serial_tools_stub = types.ModuleType("serial.tools")
+list_ports_stub = types.ModuleType("serial.tools.list_ports")
+list_ports_stub.comports = lambda *a, **k: []
+serial_tools_stub.list_ports = list_ports_stub
+serial_stub.tools = serial_tools_stub
+sys.modules.setdefault("serial", serial_stub)
+sys.modules.setdefault("serial.tools", serial_tools_stub)
+sys.modules.setdefault("serial.tools.list_ports", list_ports_stub)
+
+from adapters.uniden.bc125at_adapter import BC125ATAdapter  # noqa: E402
+
+
+def test_bc125at_sweep_parses_units(monkeypatch):
+    adapter = BC125ATAdapter()
+    monkeypatch.setattr(adapter, "enter_quick_frequency_hold", lambda ser, f: None)
+    monkeypatch.setattr(adapter, "read_rssi", lambda ser: 0)
+    result = adapter.sweep_band_scope(None, "144M", "2M", "500k")
+    assert result[0][0] == 143.0
+
+
+def test_bc125at_band_scope_auto_width(monkeypatch):
+    adapter = BC125ATAdapter()
+    monkeypatch.setattr(adapter, "enter_quick_frequency_hold", lambda ser, f: None)
+    monkeypatch.setattr(adapter, "read_rssi", lambda ser: 0)
+    adapter.sweep_band_scope(None, "146M", "2M", "0.5M")
+    assert adapter.band_scope_width == 5


### PR DESCRIPTION
## Summary
- add `sweep_band_scope` to BC125AT adapter using quick hold
- parse units for sweep utilities
- update BC125AT RSSI reader to return floats
- include basic tests for BC125AT band scope sweep

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848877607a08324891d2f95e3cff834