### PR TITLE
Add programming_session usage for band sweep

### DIFF
--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -99,3 +99,20 @@ def test_band_scope_auto_width(monkeypatch):
     output = commands["band scope"](None, adapter, "5")
     lines = output.splitlines()
     assert all(len(line) == 5 for line in lines)
+
+
+def test_configure_band_scope_wraps_programming(monkeypatch):
+    adapter = BCD325P2Adapter()
+    calls = []
+
+    def send_command_stub(ser, cmd):
+        calls.append(cmd)
+        return "OK"
+
+    monkeypatch.setattr(adapter, "send_command", send_command_stub)
+
+    adapter.configure_band_scope(None, "air")
+
+    assert calls[0] == "PRG"
+    assert calls[1].startswith("BSP")
+    assert calls[-1] == "EPG"

--- a/tests/test_bc125at_band_scope.py
+++ b/tests/test_bc125at_band_scope.py
@@ -32,3 +32,21 @@ def test_bc125at_band_scope_auto_width(monkeypatch):
     monkeypatch.setattr(adapter, "read_rssi", lambda ser: 0)
     adapter.sweep_band_scope(None, "146M", "2M", "0.5M", "0.5M")
     assert adapter.band_scope_width == 5
+
+
+def test_bc125at_configure_band_scope_wraps_programming(monkeypatch):
+    adapter = BC125ATAdapter()
+    calls = []
+
+    def send_command_stub(ser, cmd):
+        calls.append(cmd)
+        return "OK"
+
+    monkeypatch.setattr(adapter, "send_command", send_command_stub)
+    monkeypatch.setattr(adapter, "enter_quick_frequency_hold", lambda ser, f: None)
+    monkeypatch.setattr(adapter, "read_rssi", lambda ser: 0)
+
+    adapter.configure_band_scope(None, "air")
+
+    assert calls[0] == "PRG"
+    assert calls[-1] == "EPG"


### PR DESCRIPTION
## Summary
- automatically wrap BCD325P2 band sweep in `programming_session`
- implement manual band sweep wrapper for BC125AT
- verify PRG and EPG get sent around band sweep calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684892703a808324a5cc4670ed0f7074