### PR TITLE
Stream band scope generator

### DIFF
--- a/adapters/uniden/bc125at_adapter.py
+++ b/adapters/uniden/bc125at_adapter.py
@@ -173,7 +173,7 @@ class BC125ATAdapter(UnidenScannerAdapter):
             bw_mhz = self._to_mhz(bandwidth)
             if bw_mhz <= 0:
                 return None
-            width = min(int(round(span_mhz / bw_mhz)) + 1, 80)
+            width = int(round(span_mhz / bw_mhz)) + 1
             return max(width, 1)
         except Exception:
             return None

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -255,7 +255,7 @@ class BCD325P2Adapter(UnidenScannerAdapter):
             bw_mhz = self._to_mhz(bandwidth)
             if bw_mhz <= 0:
                 return None
-            width = min(int(round(span_mhz / bw_mhz)) + 1, 80)
+            width = int(round(span_mhz / bw_mhz)) + 1
             return max(width, 1)
         except Exception:
             return None

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -89,11 +89,11 @@ def test_band_scope_auto_width(monkeypatch):
     adapter.sweep_band_scope(None, "146M", "2M", "0.5M", "0.5M")
     assert adapter.band_scope_width == 5
 
-    monkeypatch.setattr(
-        adapter,
-        "stream_custom_search",
-        lambda ser, c=5: [(0, 145.0 + 0.5 * i, 0) for i in range(c)],
-    )
+    def fake_stream(ser, c=5):
+        for i in range(c):
+            yield (0, 145.0 + 0.5 * i, 0)
+
+    monkeypatch.setattr(adapter, "stream_custom_search", fake_stream)
 
     commands, _ = build_command_table(adapter, None)
     output = commands["band scope"](None, adapter, "5")

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -201,14 +201,7 @@ def build_command_table(adapter, ser):
             output = render_band_scope_waterfall(pairs, width)
 
             if width > 80:
-                split_lines = []
-                for line in output.splitlines():
-                    while len(line) > 80:
-                        split_lines.append(line[:80])
-                        line = line[80:]
-                    if line:
-                        split_lines.append(line)
-                output = "\n".join(split_lines)
+                output = split_output_lines(output, 80)
 
             return output
 


### PR DESCRIPTION
## Summary
- change custom search streaming to yield results as they're read
- derive band scope width from last sweep and handle width >80
- consume generator in `band scope` command
- update tests for generator based interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a4b325708324be92e37f51e0781a