### PR TITLE
Add band sweep command

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,16 @@ read.
 When called through the CLI's `band scope` command these readings are displayed
 as a simple two-line graph to give quick visual feedback.
 
+The related `band sweep` command streams the raw values directly. Each line
+printed contains the frequency in megahertz and the normalized RSSI level:
+
+```text
+<freq_mhz>, <rssi/1023.0>
+```
+
+For example: `162.5500, 0.450`. This format is consistent in both human and
+machine modes and is convenient for logging or further processing.
+
 ### Close Call Logging
 
 The utility function `record_close_calls` allows continuous logging of Close Call

--- a/tests/test_band_sweep.py
+++ b/tests/test_band_sweep.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import types
+import re
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+serial_stub = types.ModuleType("serial")
+serial_stub.Serial = lambda *a, **k: None
+sys.modules.setdefault("serial", serial_stub)
+
+from adapters.uniden.bcd325p2_adapter import BCD325P2Adapter  # noqa: E402
+from utilities.core.command_registry import build_command_table  # noqa: E402
+
+
+def test_band_sweep_registered_and_output(monkeypatch, capsys):
+    adapter = BCD325P2Adapter()
+
+    data = [
+        (512, 162.55, 1),
+        (256, 163.55, 0),
+    ]
+
+    def fake_stream(ser, count=1024):
+        for rssi, freq, sql in data[:count]:
+            yield rssi, freq, sql
+
+    monkeypatch.setattr(adapter, "stream_custom_search", fake_stream)
+
+    commands, help_text = build_command_table(adapter, None)
+
+    assert "band sweep" in commands
+    assert "band sweep" in help_text
+
+    commands["band sweep"](None, adapter, "2")
+    out_lines = capsys.readouterr().out.strip().splitlines()
+
+    assert len(out_lines) == 2
+    for line in out_lines:
+        assert re.match(r"^[0-9]+\.\d{4}, [01]\.\d{3}$", line)

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -215,11 +215,12 @@ def build_command_table(adapter, ser):
         def band_sweep(ser_, adapter_, arg=""):
             parts = arg.split()
             count = int(parts[0]) if parts else 1024
+            output_lines = []
             for rssi, freq, _ in adapter_.stream_custom_search(ser_, count):
                 if rssi is None or freq is None:
                     continue
-                print(f"{freq:.4f}, {rssi / 1023.0:.3f}")
-
+                output_lines.append(f"{freq:.4f}, {rssi / 1023.0:.3f}")
+            return "\n".join(output_lines)
         COMMANDS["band sweep"] = band_sweep
         COMMAND_HELP["band sweep"] = (
             "Stream band sweep data. Usage: band sweep [record_count]"

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -209,6 +209,21 @@ def build_command_table(adapter, ser):
         COMMAND_HELP["band scope"] = (
             "Stream band scope data. Usage: band scope [record_count]"
         )
+
+        logging.debug("Registering 'band sweep' command")
+
+        def band_sweep(ser_, adapter_, arg=""):
+            parts = arg.split()
+            count = int(parts[0]) if parts else 1024
+            for rssi, freq, _ in adapter_.stream_custom_search(ser_, count):
+                if rssi is None or freq is None:
+                    continue
+                print(f"{freq:.4f}, {rssi / 1023.0:.3f}")
+
+        COMMANDS["band sweep"] = band_sweep
+        COMMAND_HELP["band sweep"] = (
+            "Stream band sweep data. Usage: band sweep [record_count]"
+        )
     else:
         logging.debug("Registering placeholder 'band scope' command")
         COMMANDS["band scope"] = lambda ser_, adapter_, arg="": (


### PR DESCRIPTION
## Summary
- add new `band sweep` CLI command for streaming frequency and RSSI
- document the command in the README
- test registration and output format of `band sweep`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ae2e221483248b4093eb94c2703d