### PR TITLE
Add band select alias and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,16 @@ examples are shown below:
 | public_safety  | 1250       |
 | mil_air        | 2500       |
 
+### Band Select Command
+
+The `band select` command configures the band scope using either a preset
+name or explicit parameters. The shorter alias `band set` behaves the same.
+
+```text
+> band select air
+> band set 108M 136M 12.5k AM
+```
+
 ### Band Scope Streaming
 
 Band scope status can be streamed using the `CSC` command. When activated the

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -42,6 +42,19 @@ def test_band_select_registered(monkeypatch):
 
     assert "band select" in commands
     assert "band select" in help_text
+    assert "band set" in commands
+    assert "band set" in help_text
+
+
+def test_band_set_alias(monkeypatch):
+    adapter = BCD325P2Adapter()
+    adapter.in_program_mode = True
+    monkeypatch.setattr(adapter, "send_command", lambda ser, cmd: cmd)
+
+    commands, _ = build_command_table(adapter, None)
+    result_alias = commands["band set"](None, adapter, "air")
+    result_select = commands["band select"](None, adapter, "air")
+    assert result_alias == result_select
 
 
 def test_custom_search_returns_pairs(monkeypatch):

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -243,6 +243,7 @@ def build_command_table(adapter, ser):
             return adapter_.configure_band_scope(ser_, *parts)
 
         COMMANDS["band select"] = band_select
+        COMMANDS["band set"] = band_select
 
         try:
             from config.band_scope_presets import BAND_SCOPE_PRESETS
@@ -252,10 +253,12 @@ def build_command_table(adapter, ser):
         except ImportError:
             preset_help = ""
 
-        COMMAND_HELP["band select"] = (
+        help_msg = (
             f"Select a band using a preset. Usage: band select <preset> or "
             f"band select <low_freq> <high_freq> <step> <modulation>.{preset_help}"
         )
+        COMMAND_HELP["band select"] = help_msg
+        COMMAND_HELP["band set"] = help_msg
     else:
         logging.debug("Registering placeholder 'band select' command")
         COMMANDS["band select"] = lambda ser_, adapter_, arg: (


### PR DESCRIPTION
## Summary
- document `band select` usage in README
- alias `band set` -> `band select`
- test alias in `test_band_scope`

## Testing
- `pytest -q` *(fails: test_band_sweep_registered_and_output)*

------
https://chatgpt.com/codex/tasks/task_e_6848b7c27dc08324bf88d2aa8e806be3