### PR TITLE
Enable automatic band-scope search start

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,15 @@ name or explicit parameters. The shorter alias `band set` behaves the same.
 > band set 108M 136M 12.5k AM
 ```
 
+After the `BSP` command is sent during `band select`, the scanner now
+automatically enters band-scope search by issuing a scan-start key.
+If the search is later halted you can resume it with the dedicated
+command:
+
+```text
+> band scope start
+```
+
 ### Band Scope Streaming
 
 Band scope status can be streamed using the `CSC` command. When activated the

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -239,6 +239,13 @@ class BCD325P2Adapter(UnidenScannerAdapter):
                     span, bandwidth or step
                 )
                 self.signal_bandwidth = bandwidth
+                # Automatically start band-scope search after configuring
+                # the system settings so the user immediately enters the
+                # sweep mode.
+                try:
+                    self.start_scanning(ser)
+                except Exception as e:  # pragma: no cover - log and proceed
+                    logger.error(f"Error starting band scope search: {e}")
                 return self.feedback(True, response_str)
         except Exception as e:
             return self.feedback(False, f"Error configuring band scope: {e}")

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -123,9 +123,11 @@ def test_configure_band_scope_wraps_programming(monkeypatch):
         return "OK"
 
     monkeypatch.setattr(adapter, "send_command", send_command_stub)
+    monkeypatch.setattr(adapter, "start_scanning", lambda ser: calls.append("START"))
 
     adapter.configure_band_scope(None, "air")
 
     assert calls[0] == "PRG"
     assert calls[1].startswith("BSP")
+    assert calls[2] == "START"
     assert calls[-1] == "EPG"

--- a/tests/test_band_sweep.py
+++ b/tests/test_band_sweep.py
@@ -13,7 +13,7 @@ from adapters.uniden.bcd325p2_adapter import BCD325P2Adapter  # noqa: E402
 from utilities.core.command_registry import build_command_table  # noqa: E402
 
 
-def test_band_sweep_registered_and_output(monkeypatch, capsys):
+def test_band_sweep_registered_and_output(monkeypatch):
     adapter = BCD325P2Adapter()
 
     data = [
@@ -32,8 +32,8 @@ def test_band_sweep_registered_and_output(monkeypatch, capsys):
     assert "band sweep" in commands
     assert "band sweep" in help_text
 
-    commands["band sweep"](None, adapter, "2")
-    out_lines = capsys.readouterr().out.strip().splitlines()
+    output = commands["band sweep"](None, adapter, "2")
+    out_lines = output.splitlines()
 
     assert len(out_lines) == 2
     for line in out_lines:

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -25,12 +25,18 @@ def test_scan_start_stop_registered(monkeypatch):
 
     assert "scan start" in commands
     assert "scan stop" in commands
+    assert "band scope start" in commands
     assert help_text["scan start"] == "Start scanner scanning process."
     assert help_text["scan stop"] == "Stop scanner scanning process."
+    assert (
+        help_text["band scope start"]
+        == "Begin band-scope search using current settings."
+    )
 
     # Ensure commands use adapter methods
     assert commands["scan start"](None, adapter) == "KEY:S"
     assert commands["scan stop"](None, adapter) == "KEY:H"
+    assert commands["band scope start"](None, adapter) == "KEY:S"
 
 
 def test_bsp_and_bsv_commands_present(monkeypatch):

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -357,6 +357,7 @@ def build_command_table(adapter, ser):
             "Start scanner scanning process. "
             "(Not available for this scanner model)"
         )
+        logging.debug("Registering placeholder 'band scope start' command")
         COMMANDS["band scope start"] = lambda ser_, adapter_: (
             "Command 'band scope start' not supported on this scanner model"
         )

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -341,6 +341,13 @@ def build_command_table(adapter, ser):
             ser_
         )
         COMMAND_HELP["scan start"] = "Start scanner scanning process."
+        logging.debug("Registering 'band scope start' command")
+        COMMANDS["band scope start"] = lambda ser_, adapter_: adapter_.start_scanning(
+            ser_
+        )
+        COMMAND_HELP["band scope start"] = (
+            "Begin band-scope search using current settings."
+        )
     else:
         logging.debug("Registering placeholder 'scan start' command")
         COMMANDS["scan start"] = lambda ser_, adapter_: (
@@ -349,6 +356,12 @@ def build_command_table(adapter, ser):
         COMMAND_HELP["scan start"] = (
             "Start scanner scanning process. "
             "(Not available for this scanner model)"
+        )
+        COMMANDS["band scope start"] = lambda ser_, adapter_: (
+            "Command 'band scope start' not supported on this scanner model"
+        )
+        COMMAND_HELP["band scope start"] = (
+            "Begin band-scope search. (Not available for this scanner model)"
         )
 
     if hasattr(adapter, 'stop_scanning'):


### PR DESCRIPTION
## Summary
- start band-scope search automatically after sending BSP
- expose new `band scope start` command
- document the workflow in README
- fix band sweep test and update band scope tests

## Testing
- `pre-commit run --files README.md adapters/uniden/bcd325p2_adapter.py tests/test_band_scope.py tests/test_band_sweep.py tests/test_command_registry.py utilities/core/command_registry.py` *(fails: CalledProcessError due to network)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848bd98ed9c8324a12056238b9007a6