### PR TITLE
Handle empty band scope

### DIFF
--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -152,3 +152,18 @@ def test_band_scope_output_wrapped(monkeypatch):
     # Output should be wrapped so no line exceeds 80 characters
     assert len(lines) == 2
     assert all(len(line) <= 80 for line in lines)
+
+
+def test_band_scope_no_data(monkeypatch):
+    adapter = BCD325P2Adapter()
+
+    def empty_stream(ser, c=5):
+        if False:
+            yield  # pragma: no cover
+
+    monkeypatch.setattr(adapter, "stream_custom_search", empty_stream)
+
+    commands, _ = build_command_table(adapter, None)
+    result = commands["band scope"](None, adapter, "5")
+
+    assert result == "No band scope data received"

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -158,8 +158,7 @@ def test_band_scope_no_data(monkeypatch):
     adapter = BCD325P2Adapter()
 
     def empty_stream(ser, c=5):
-        if False:
-            yield  # pragma: no cover
+        yield from []
 
     monkeypatch.setattr(adapter, "stream_custom_search", empty_stream)
 

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -202,6 +202,8 @@ def build_command_table(adapter, ser):
                 pairs.append(
                     (freq, rssi / 1023.0 if rssi is not None else None)
                 )
+            if not pairs:
+                return "No band scope data received"
             output = render_band_scope_waterfall(pairs, width)
 
             if width > 80:


### PR DESCRIPTION
## Summary
- add check for empty band scope results
- test the new no-data behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848c2804de48324a17e847e0fa0a44e