### PR TITLE
Fix band scope width and add tests

### DIFF
--- a/adapters/uniden/bc125at_adapter.py
+++ b/adapters/uniden/bc125at_adapter.py
@@ -174,7 +174,11 @@ class BC125ATAdapter(UnidenScannerAdapter):
         """Return the number of sweep bins from span and bandwidth values."""
         try:
             span_mhz = self._to_mhz(span)
-            bw_mhz = self._to_mhz(bandwidth)
+            bw_val = str(bandwidth).strip().lower()
+            if any(bw_val.endswith(s) for s in ("mhz", "m", "khz", "k")):
+                bw_mhz = self._to_mhz(bandwidth)
+            else:
+                bw_mhz = float(bw_val) / 1000.0
             if bw_mhz <= 0:
                 return None
             width = int(round(span_mhz / bw_mhz)) + 1

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -276,7 +276,11 @@ class BCD325P2Adapter(UnidenScannerAdapter):
         """Return the number of sweep bins from span and bandwidth values."""
         try:
             span_mhz = self._to_mhz(span)
-            bw_mhz = self._to_mhz(bandwidth)
+            bw_val = str(bandwidth).strip().lower()
+            if any(bw_val.endswith(s) for s in ("mhz", "m", "khz", "k")):
+                bw_mhz = self._to_mhz(bandwidth)
+            else:
+                bw_mhz = float(bw_val) / 1000.0
             if bw_mhz <= 0:
                 return None
             width = int(round(span_mhz / bw_mhz)) + 1

--- a/tests/test_bc125at_band_scope.py
+++ b/tests/test_bc125at_band_scope.py
@@ -20,7 +20,9 @@ from adapters.uniden.bc125at_adapter import BC125ATAdapter  # noqa: E402
 
 def test_bc125at_sweep_parses_units(monkeypatch):
     adapter = BC125ATAdapter()
-    monkeypatch.setattr(adapter, "enter_quick_frequency_hold", lambda ser, f: None)
+    monkeypatch.setattr(
+        adapter, "enter_quick_frequency_hold", lambda ser, f: None
+    )
     monkeypatch.setattr(adapter, "read_rssi", lambda ser: 0)
     result = adapter.sweep_band_scope(None, "144M", "2M", "500k", "500k")
     assert result[0][0] == 143.0
@@ -28,7 +30,9 @@ def test_bc125at_sweep_parses_units(monkeypatch):
 
 def test_bc125at_band_scope_auto_width(monkeypatch):
     adapter = BC125ATAdapter()
-    monkeypatch.setattr(adapter, "enter_quick_frequency_hold", lambda ser, f: None)
+    monkeypatch.setattr(
+        adapter, "enter_quick_frequency_hold", lambda ser, f: None
+    )
     monkeypatch.setattr(adapter, "read_rssi", lambda ser: 0)
     adapter.sweep_band_scope(None, "146M", "2M", "0.5M", "0.5M")
     assert adapter.band_scope_width == 5
@@ -43,10 +47,26 @@ def test_bc125at_configure_band_scope_wraps_programming(monkeypatch):
         return "OK"
 
     monkeypatch.setattr(adapter, "send_command", send_command_stub)
-    monkeypatch.setattr(adapter, "enter_quick_frequency_hold", lambda ser, f: None)
+    monkeypatch.setattr(
+        adapter, "enter_quick_frequency_hold", lambda ser, f: None
+    )
     monkeypatch.setattr(adapter, "read_rssi", lambda ser: 0)
 
     adapter.configure_band_scope(None, "air")
 
     assert calls[0] == "PRG"
     assert calls[-1] == "EPG"
+
+
+def test_bc125at_configure_band_scope_sets_width(monkeypatch):
+    adapter = BC125ATAdapter()
+    adapter.in_program_mode = True
+
+    monkeypatch.setattr(adapter, "send_command", lambda ser, cmd: "OK")
+    monkeypatch.setattr(
+        adapter, "enter_quick_frequency_hold", lambda ser, f: None
+    )
+    monkeypatch.setattr(adapter, "read_rssi", lambda ser: 0)
+
+    adapter.configure_band_scope(None, "air")
+    assert adapter.band_scope_width and adapter.band_scope_width > 1


### PR DESCRIPTION
## Summary
- interpret numeric step/bandwidth values as kHz in `_calc_band_scope_width`
- ensure preset-based band scope configuration stores a reasonable width
- test that band scope width is set when selecting presets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849cd14d0408324aa8be1e12f706a07