### PR TITLE
Fix band scope center frequency format

### DIFF
--- a/adapters/uniden/bc125at_adapter.py
+++ b/adapters/uniden/bc125at_adapter.py
@@ -230,7 +230,7 @@ class BC125ATAdapter(UnidenScannerAdapter):
         high_khz = self._to_khz(high)
         span_mhz = (high_khz - low_khz) / 1000.0
         center_khz = (low_khz + high_khz) / 2.0
-        freq = f"{int(round(center_khz)):08d}"
+        freq = f"{int(round(center_khz * 10)):08d}"
         span = f"{span_mhz:g}M"
 
         with programming_session(self, ser) as ok:

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -211,7 +211,7 @@ class BCD325P2Adapter(UnidenScannerAdapter):
         high_khz = self._to_khz(high)
         span_mhz = (high_khz - low_khz) / 1000.0
         center_khz = (low_khz + high_khz) / 2.0
-        freq = f"{int(round(center_khz)):08d}"
+        freq = f"{int(round(center_khz * 10)):08d}"
         span = f"{span_mhz:g}M"
         max_hold = 0
         bandwidth = None

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -32,7 +32,7 @@ def test_band_select_air_command(monkeypatch):
 
     commands, _ = build_command_table(adapter, None)
     result = commands["band select"](None, adapter, "air")
-    assert result == "BSP,00125000,833,20M,0"
+    assert result == "BSP,01250000,833,20M,0"
 
 
 def test_band_select_registered(monkeypatch):

--- a/utilities/validators.py
+++ b/utilities/validators.py
@@ -161,5 +161,5 @@ def validate_frequency_8_digit(value):
 
     value_str = str(value).strip()
     if not value_str.isdigit() or len(value_str) != 8:
-        raise ValueError("Frequency must be an 8-digit value (e.g., 00125000)")
+        raise ValueError("Frequency must be an 8-digit value (e.g., 01250000)")
     return value_str


### PR DESCRIPTION
## Summary
- compute band scope center frequency using center_khz * 10
- update message in frequency validator
- adjust expected band scope command in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d7034d4c8324b57a45eacb5f8745