### PR TITLE
Fix band scope width calculation

### DIFF
--- a/adapters/uniden/bc125at_adapter.py
+++ b/adapters/uniden/bc125at_adapter.py
@@ -171,14 +171,22 @@ class BC125ATAdapter(UnidenScannerAdapter):
         return float(value_str)
 
     def _calc_band_scope_width(self, span, bandwidth):
-        """Return the number of sweep bins from span and bandwidth values."""
+        """Return the number of sweep bins from span and bandwidth values.
+
+        Bare integers are interpreted as hundredths of a kilohertz
+        (e.g. ``833`` becomes ``8.33 kHz``).
+        """
         try:
             span_mhz = self._to_mhz(span)
             bw_val = str(bandwidth).strip().lower()
             if any(bw_val.endswith(s) for s in ("mhz", "m", "khz", "k")):
                 bw_mhz = self._to_mhz(bandwidth)
             else:
-                bw_mhz = float(bw_val) / 1000.0
+                if bw_val.lstrip("-+").isdigit():
+                    bw_khz = float(bw_val) / 100.0
+                else:
+                    bw_khz = float(bw_val)
+                bw_mhz = bw_khz / 1000.0
             if bw_mhz <= 0:
                 return None
             width = int(round(span_mhz / bw_mhz)) + 1

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -273,14 +273,22 @@ class BCD325P2Adapter(UnidenScannerAdapter):
         return float(value_str)
 
     def _calc_band_scope_width(self, span, bandwidth):
-        """Return the number of sweep bins from span and bandwidth values."""
+        """Return the number of sweep bins from span and bandwidth values.
+
+        Bare integers are interpreted as hundredths of a kilohertz
+        (e.g. ``833`` becomes ``8.33 kHz``).
+        """
         try:
             span_mhz = self._to_mhz(span)
             bw_val = str(bandwidth).strip().lower()
             if any(bw_val.endswith(s) for s in ("mhz", "m", "khz", "k")):
                 bw_mhz = self._to_mhz(bandwidth)
             else:
-                bw_mhz = float(bw_val) / 1000.0
+                if bw_val.lstrip("-+").isdigit():
+                    bw_khz = float(bw_val) / 100.0
+                else:
+                    bw_khz = float(bw_val)
+                bw_mhz = bw_khz / 1000.0
             if bw_mhz <= 0:
                 return None
             width = int(round(span_mhz / bw_mhz)) + 1

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -143,7 +143,7 @@ def test_configure_band_scope_sets_width(monkeypatch):
     monkeypatch.setattr(adapter, "start_scanning", lambda ser: None)
 
     adapter.configure_band_scope(None, "air")
-    assert adapter.band_scope_width and adapter.band_scope_width > 1
+    assert adapter.band_scope_width == 2402
 
     def fake_stream(ser, c=adapter.band_scope_width):
         for i in range(c):
@@ -154,7 +154,7 @@ def test_configure_band_scope_sets_width(monkeypatch):
     commands, _ = build_command_table(adapter, None)
     output = commands["band scope"](None, adapter, "5")
     lines = output.splitlines()
-    assert all(len(line) == adapter.band_scope_width for line in lines)
+    assert all(len(line) <= 80 for line in lines)
 
 
 def test_band_scope_output_wrapped(monkeypatch):

--- a/tests/test_bc125at_band_scope.py
+++ b/tests/test_bc125at_band_scope.py
@@ -69,4 +69,4 @@ def test_bc125at_configure_band_scope_sets_width(monkeypatch):
     monkeypatch.setattr(adapter, "read_rssi", lambda ser: 0)
 
     adapter.configure_band_scope(None, "air")
-    assert adapter.band_scope_width and adapter.band_scope_width > 1
+    assert adapter.band_scope_width == 2402


### PR DESCRIPTION
## Summary
- handle bare integers correctly in `_calc_band_scope_width`
- document new behavior in adapters
- expect large width when configuring the 'air' preset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d9a6832c83248c5ecaaa597117cb