### PR TITLE
Update send_command program mode tracking

### DIFF
--- a/adapters/uniden/common/core.py
+++ b/adapters/uniden/common/core.py
@@ -211,6 +211,13 @@ def send_command(self, ser, cmd):
             f"Value: {response!r}"
         )
 
+        # Update programming mode flag when manually issuing PRG/EPG
+        clean_cmd = cmd_str.strip().upper()
+        if clean_cmd in {"PRG", "EPG"} and hasattr(self, "in_program_mode"):
+            resp_str = ensure_str(response)
+            if "OK" in resp_str:
+                self.in_program_mode = clean_cmd == "PRG"
+
         # Make sure we return bytes for consistency
         return ensure_bytes(response)
     except Exception as e:

--- a/adapters/uniden/uniden_base_adapter.py
+++ b/adapters/uniden/uniden_base_adapter.py
@@ -70,6 +70,12 @@ class UnidenScannerAdapter(BaseScannerAdapter):
                 f"Value: {response!r}"
             )
 
+            clean_cmd = cmd_str.strip().upper()
+            if clean_cmd in {"PRG", "EPG"} and hasattr(self, "in_program_mode"):
+                resp_str = self.ensure_str(response)
+                if "OK" in resp_str:
+                    self.in_program_mode = clean_cmd == "PRG"
+
             # Return bytes for consistency
             return self.ensure_bytes(response)
         except Exception as e:

--- a/tests/test_program_flag.py
+++ b/tests/test_program_flag.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import types
+
+# Ensure project modules can be imported
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide a minimal serial stub
+serial_stub = types.ModuleType("serial")
+serial_stub.Serial = lambda *a, **k: None
+serial_tools_stub = types.ModuleType("serial.tools")
+list_ports_stub = types.ModuleType("serial.tools.list_ports")
+list_ports_stub.comports = lambda *a, **k: []
+serial_tools_stub.list_ports = list_ports_stub
+serial_stub.tools = serial_tools_stub
+sys.modules.setdefault("serial", serial_stub)
+sys.modules.setdefault("serial.tools", serial_tools_stub)
+sys.modules.setdefault("serial.tools.list_ports", list_ports_stub)
+
+from adapters.uniden.bc125at_adapter import BC125ATAdapter  # noqa: E402
+import utilities.scanner.backend as backend  # noqa: E402
+
+
+def test_prg_toggles_flag(monkeypatch):
+    adapter = BC125ATAdapter()
+    adapter.in_program_mode = False
+    monkeypatch.setattr(backend, "send_command", lambda ser, cmd: "OK")
+
+    resp = adapter.send_command(None, "PRG")
+    assert resp == b"OK"
+    assert adapter.in_program_mode
+
+
+def test_epg_toggles_flag(monkeypatch):
+    adapter = BC125ATAdapter()
+    adapter.in_program_mode = True
+    monkeypatch.setattr(backend, "send_command", lambda ser, cmd: "OK")
+
+    resp = adapter.send_command(None, "EPG")
+    assert resp == b"OK"
+    assert not adapter.in_program_mode


### PR DESCRIPTION
## Summary
- update `send_command` wrappers to toggle `in_program_mode` on PRG/EPG
- test that issuing PRG/EPG manually updates the flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849dc0de1ec8324a334e8b4e5ef450e