### PR TITLE
Implement baseline and log scaling for band scope

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,1 +1,4 @@
 # Configuration modules for scanner-controller.
+
+# Default band scope options
+BAND_SCOPE_LOG_SCALE = False


### PR DESCRIPTION
## Summary
- compute and subtract baseline RSSI in band scope handler
- optionally allow logarithmic scaling via argument/config
- expose `BAND_SCOPE_LOG_SCALE` config flag
- test baseline correction and log scaling behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b45927650832499a26343e75d2f55