### PR TITLE
Add numeric custom search parsing

### DIFF
--- a/adapters/uniden/bcd325p2/custom_search.py
+++ b/adapters/uniden/bcd325p2/custom_search.py
@@ -43,7 +43,10 @@ def stream_custom_search(self, ser, record_count=1024):
             if len(parts) >= 4:
                 try:
                     rssi = int(parts[1])
-                    freq = float(parts[2])
+                    if parts[2].isdigit():
+                        freq = int(parts[2]) / 10000.0
+                    else:
+                        freq = float(parts[2])
                     sql = int(parts[3])
                     yield (rssi, freq, sql)
                     count += 1

--- a/tests/test_custom_search.py
+++ b/tests/test_custom_search.py
@@ -33,7 +33,7 @@ def test_band_scope_command_registered(monkeypatch):
 
 def test_band_scope_collects(monkeypatch):
     adapter = BCD325P2Adapter()
-    data_lines = ["CSC,10,162.0,1", "CSC,11,163.0,0", "CSC,OK"]
+    data_lines = ["CSC,10,01620000,1", "CSC,11,01630000,0", "CSC,OK"]
 
     monkeypatch.setattr(adapter, "send_command", lambda ser, cmd, delay=0: "")
 


### PR DESCRIPTION
## Summary
- parse numeric frequencies without decimals in `stream_custom_search`
- update custom search test to use integer frequency format

## Testing
- `pytest -q tests/test_custom_search.py`
- `pytest -q tests/test_band_scope.py`

------
https://chatgpt.com/codex/tasks/task_e_684b55c614148324bb2374999226ce0b