### PR TITLE
Fix BCD325P2 band select span limits

### DIFF
--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -245,6 +245,8 @@ class BCD325P2Adapter(UnidenScannerAdapter):
             450,
             500,
         ]
+        # Select the smallest span value from the allowed_spans list that is greater than or equal to span_mhz.
+        # If no such value exists, default to the largest value in the list.
         span_val = next((s for s in allowed_spans if s >= span_mhz), allowed_spans[-1])
         span = f"{span_val:g}M"
         max_hold = 0

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -216,12 +216,42 @@ class BCD325P2Adapter(UnidenScannerAdapter):
         span_mhz = (high_khz - low_khz) / 1000.0
         center_khz = (low_khz + high_khz) / 2.0
         freq = f"{int(round(center_khz * 10)):08d}"
-        span = f"{span_mhz:g}M"
+
+        allowed_spans = [
+            0.2,
+            0.4,
+            0.6,
+            0.8,
+            1,
+            2,
+            4,
+            6,
+            8,
+            10,
+            20,
+            40,
+            60,
+            80,
+            100,
+            120,
+            140,
+            160,
+            180,
+            200,
+            250,
+            300,
+            350,
+            400,
+            450,
+            500,
+        ]
+        span_val = next((s for s in allowed_spans if s >= span_mhz), allowed_spans[-1])
+        span = f"{span_val:g}M"
         max_hold = 0
         bandwidth = None
 
         self.last_center = center_khz / 1000.0
-        self.last_span = span_mhz
+        self.last_span = span_val
         self.last_step = self._to_mhz(step)
         self.last_mod = mod
 

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -35,7 +35,7 @@ def test_band_select_air_command(monkeypatch):
 
     commands, _ = build_command_table(adapter, None)
     result = commands["band select"](None, adapter, "air")
-    assert result == "BSP,01220000,833,28M,0"
+    assert result == "BSP,01220000,833,40M,0"
 
 
 def test_band_select_registered(monkeypatch):
@@ -149,7 +149,7 @@ def test_configure_band_scope_sets_width(monkeypatch):
     monkeypatch.setattr(adapter.commands["BSP"], "validator", None)
 
     adapter.configure_band_scope(None, "air")
-    assert adapter.band_scope_width == 3362
+    assert adapter.band_scope_width == 4803
 
     def fake_stream(ser, c=adapter.band_scope_width):
         for i in range(c):


### PR DESCRIPTION
## Summary
- adjust `BCD325P2Adapter.configure_band_scope` to round band span to the
  next valid value supported by BSP
- update tests for new span behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b450db354832488aefb1432ddba66