### PR TITLE
Check adapter program mode in band scope

### DIFF
--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -291,3 +291,25 @@ def test_band_scope_summary_line(monkeypatch):
     assert "span=2M" in lines[-1]
     assert "step=500k" in lines[-1]
     assert "mod=FM" in lines[-1]
+
+
+def test_band_scope_in_program_mode(monkeypatch):
+    adapter = BCD325P2Adapter()
+    adapter.in_program_mode = True
+
+    called = []
+
+    def stream_stub(ser, c=3):
+        called.append(True)
+        yield (10, 145.0, 0)
+
+    monkeypatch.setattr(adapter, "stream_custom_search", stream_stub)
+
+    commands, _ = build_command_table(adapter, None)
+    result = commands["band scope"](None, adapter, "3")
+
+    assert (
+        result
+        == "Scanner is in programming mode. Run 'send EPG' then 'band scope start'."
+    )
+    assert not called

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -210,6 +210,12 @@ def build_command_table(adapter, ser):
 
             width = getattr(adapter_, "band_scope_width", 64) or 64
 
+            if getattr(adapter_, "in_program_mode", False):
+                return (
+                    "Scanner is in programming mode. "
+                    "Run 'send EPG' then 'band scope start'."
+                )
+
             records = []
             baseline = None
             for rssi, freq, _ in adapter_.stream_custom_search(ser_, count):


### PR DESCRIPTION
## Summary
- ensure `band_scope` refuses to run while the scanner is in programming mode
- test the new message

## Testing
- `pre-commit run --files utilities/core/command_registry.py tests/test_band_scope.py` *(fails: unable to access github.com)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b5c74fb6483249462e23ef7952c38