### PR TITLE
Replace setup.py bullet with pyproject

### DIFF
--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -9,7 +9,7 @@ The root directory should be kept clean and contain only essential files:
 - `README.md` - Project documentation
 - `LICENSE` - License information
 - `run_scanner_gui.py` - Main entry point for the GUI application
-- `setup.py` - Package installation script
+- `pyproject.toml` - Packaging configuration file
 - `requirements.txt` - Production dependencies
 - `requirements-dev.txt` - Development dependencies
 - `.gitignore` - Git ignore file


### PR DESCRIPTION
## Summary
- update project structure docs to mention `pyproject.toml` instead of `setup.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68895570ac40832498bbad063ca2aa5b