### PR TITLE
Add BC125AT scan controls

### DIFF
--- a/adapters/uniden/bc125at/user_control.py
+++ b/adapters/uniden/bc125at/user_control.py
@@ -35,3 +35,13 @@ def send_key(self, ser, key_seq):
             success = False
 
     return self.feedback(success, "\n".join(responses))
+
+
+def start_scanning(self, ser):
+    """Resume scanning mode."""
+    return self.send_key(ser, "S")
+
+
+def stop_scanning(self, ser):
+    """Hold on current channel/frequency."""
+    return self.send_key(ser, "H")

--- a/tests/test_bc125at_band_scope.py
+++ b/tests/test_bc125at_band_scope.py
@@ -53,10 +53,12 @@ def test_bc125at_configure_band_scope_wraps_programming(monkeypatch):
         adapter, "enter_quick_frequency_hold", lambda ser, f: None
     )
     monkeypatch.setattr(adapter, "read_rssi", lambda ser: 0)
+    monkeypatch.setattr(adapter, "start_scanning", lambda ser: calls.append("START"))
 
     adapter.configure_band_scope(None, "air")
 
     assert calls[0] == "PRG"
+    assert "START" in calls
     assert calls[-1] == "EPG"
 
 
@@ -69,6 +71,7 @@ def test_bc125at_configure_band_scope_sets_width(monkeypatch):
         adapter, "enter_quick_frequency_hold", lambda ser, f: None
     )
     monkeypatch.setattr(adapter, "read_rssi", lambda ser: 0)
+    monkeypatch.setattr(adapter, "start_scanning", lambda ser: None)
 
     adapter.configure_band_scope(None, "air")
     assert adapter.band_scope_width == 3362


### PR DESCRIPTION
## Summary
- implement `start_scanning` and `stop_scanning` for BC125AT scanners
- expose scan control helpers on `BC125ATAdapter`
- auto-resume scanning after `band select`
- update bc125at band scope tests and scan control tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688974637f448324addcecfc2c54bb7c