### PR TITLE
Add list hits option to band scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,15 @@ the sweep parameters is printed after the waterfall output:
 center=146.000 min=145.000 max=147.000 span=2M step=0.5M mod=FM
 ```
 
+To get a plain list of hit frequencies instead of a graph, append `list` or
+`hits` to the command. Only results with RSSI above zero are printed:
+
+```text
+> band scope list
+146.5200
+147.0400
+```
+
 The related `band sweep` command streams the raw values directly. Each line
 printed contains the frequency in megahertz and the normalized RSSI level:
 

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -315,3 +315,19 @@ def test_band_scope_in_program_mode(monkeypatch):
         == "Scanner is in programming mode. Run 'send EPG' then 'band scope start'."
     )
     assert not called
+
+
+def test_band_scope_list_hits(monkeypatch):
+    adapter = BCD325P2Adapter()
+
+    def stream_stub(ser, c=1024):
+        yield (0, 145.0, 0)
+        yield (50, 146.0, 1)
+        yield (0, 147.0, 0)
+        yield (30, 148.0, 0)
+
+    monkeypatch.setattr(adapter, "stream_custom_search", stream_stub)
+
+    commands, _ = build_command_table(adapter, None)
+    output = commands["band scope"](None, adapter, "list")
+    assert output.splitlines() == ["146.0000", "148.0000"]

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -199,9 +199,12 @@ def build_command_table(adapter, ser):
             parts = arg.split()
             count = 1024
             log_scale = getattr(config, "BAND_SCOPE_LOG_SCALE", False)
+            list_hits = False
             for part in parts:
                 if part.lower() == "log":
                     log_scale = True
+                elif part.lower() in ("list", "hits"):
+                    list_hits = True
                 else:
                     try:
                         count = int(part)
@@ -217,14 +220,20 @@ def build_command_table(adapter, ser):
                 )
 
             records = []
+            hits = []
             baseline = None
             for rssi, freq, _ in adapter_.stream_custom_search(ser_, count):
                 records.append((rssi, freq))
                 if rssi and rssi > 0:
                     baseline = rssi if baseline is None else min(baseline, rssi)
+                    if list_hits:
+                        hits.append(f"{freq:.4f}")
 
             if not records:
                 return "No band scope data received"
+
+            if list_hits:
+                return "\n".join(hits)
 
             baseline = baseline or 0
             max_db = (
@@ -292,7 +301,7 @@ def build_command_table(adapter, ser):
 
         COMMANDS["band scope"] = band_scope
         COMMAND_HELP["band scope"] = (
-            "Stream band scope data. Usage: band scope [record_count]"
+            "Stream band scope data. Usage: band scope [record_count] [log|list|hits]"
         )
 
         logging.debug("Registering 'band sweep' command")


### PR DESCRIPTION
## Summary
- support new optional argument for `band scope` to list hit frequencies
- document `band scope list` usage
- add tests for hit frequency listing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688982da4afc83249cc406f247ebad64