### PR TITLE
Remove CLI band scope graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,22 +185,14 @@ The controller now gathers a configurable number of these records before
 stopping the stream. By default, **1024** records are collected. After the limit
 is reached the command `CSC,OFF` is issued and the final `CSC,OK` response is
 read.
-When called through the CLI's `band scope` command these readings are displayed
-as a simple two-line graph to give quick visual feedback. A summary line with
-the sweep parameters is printed after the waterfall output:
+When called through the CLI's `band scope` command the detected frequencies are
+listed one per line. A summary line with the sweep parameters is printed after
+the frequency list:
 
 ```text
-(graph lines)
-center=146.000 min=145.000 max=147.000 span=2M step=0.5M mod=FM
-```
-
-To get a plain list of hit frequencies instead of a graph, append `list` or
-`hits` to the command. Only results with RSSI above zero are printed:
-
-```text
-> band scope list
 146.5200
 147.0400
+center=146.000 min=145.000 max=147.000 span=2M step=0.5M mod=FM
 ```
 
 The related `band sweep` command streams the raw values directly. Each line
@@ -266,11 +258,13 @@ Connected to /dev/ttyUSB1 [ID 2]
 > use 1
 Using connection 1
 > band scope 20
-(graph for scanner 1)
+146.5200
+146.5400
 > use 2
 Using connection 2
 > band scope 20
-(graph for scanner 2)
+146.5200
+146.5400
 ```
 
 ## Extending the System

--- a/tests/test_custom_search.py
+++ b/tests/test_custom_search.py
@@ -29,8 +29,8 @@ def test_band_scope_command_registered(monkeypatch):
     assert "band scope" in help_text
     output = commands["band scope"](None, adapter, "10")
     lines = output.splitlines()
-    assert len(lines) == 3
-    assert all(len(line) == 5 for line in lines[:-1])
+    assert len(lines) == 1
+    assert lines[0].startswith("center=")
 
 
 def test_band_scope_collects(monkeypatch):
@@ -52,3 +52,4 @@ def test_band_scope_collects(monkeypatch):
     results = list(adapter.stream_custom_search(None, 2))
 
     assert results == [(10, 162.0, 1), (11, 163.0, 0)]
+


### PR DESCRIPTION
## Summary
- drop waterfall rendering in `band scope`
- list hit frequencies instead and always print a summary
- adjust README examples
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68899233c82c8324ad114bc737089f6e