### PR TITLE
Change band scope to list output

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,22 +185,14 @@ The controller now gathers a configurable number of these records before
 stopping the stream. By default, **1024** records are collected. After the limit
 is reached the command `CSC,OFF` is issued and the final `CSC,OK` response is
 read.
-When called through the CLI's `band scope` command these readings are displayed
-as a simple two-line graph to give quick visual feedback. A summary line with
-the sweep parameters is printed after the waterfall output:
+When called through the CLI's `band scope` command these readings are printed as
+a list of hit frequencies. After all hits a summary line describes the sweep
+parameters. Only results with RSSI above zero are printed:
 
 ```text
-(graph lines)
-center=146.000 min=145.000 max=147.000 span=2M step=0.5M mod=FM
-```
-
-To get a plain list of hit frequencies instead of a graph, append `list` or
-`hits` to the command. Only results with RSSI above zero are printed:
-
-```text
-> band scope list
 146.5200
 147.0400
+center=146.000 min=145.000 max=147.000 span=2M step=0.5M mod=FM
 ```
 
 The related `band sweep` command streams the raw values directly. Each line
@@ -266,11 +258,13 @@ Connected to /dev/ttyUSB1 [ID 2]
 > use 1
 Using connection 1
 > band scope 20
-(graph for scanner 1)
+(hits for scanner 1)
+center=...
 > use 2
 Using connection 2
 > band scope 20
-(graph for scanner 2)
+(hits for scanner 2)
+center=...
 ```
 
 ## Extending the System

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -1,4 +1,4 @@
-"""Tests for rendering the band scope waterfall and presets."""
+"""Tests for band scope command behavior and presets."""
 
 import os
 import sys
@@ -14,8 +14,6 @@ sys.modules.setdefault("serial", serial_stub)
 import importlib
 from adapters.uniden.bcd325p2_adapter import BCD325P2Adapter  # noqa: E402
 from utilities.core.command_registry import build_command_table  # noqa: E402
-from utilities.graph_utils import render_band_scope_waterfall
-import pytest
 
 
 def test_presets_load():
@@ -84,20 +82,6 @@ def test_custom_search_parses_units(monkeypatch):
     assert result[0][0] == 143.0
 
 
-def test_render_band_scope_waterfall_wrap():
-    pairs = [
-        (100.0, 0.0),
-        (101.0, 0.5),
-        (102.0, 1.0),
-        (100.0, 1.0),
-        (101.0, 0.5),
-        (102.0, 0.0),
-    ]
-    output = render_band_scope_waterfall(pairs, width=3)
-    lines = output.splitlines()
-    assert len(lines) == 2
-    assert all(len(line) == 3 for line in lines)
-
 
 def test_band_scope_auto_width(monkeypatch):
     adapter = BCD325P2Adapter()
@@ -116,7 +100,8 @@ def test_band_scope_auto_width(monkeypatch):
     commands, _ = build_command_table(adapter, None)
     output = commands["band scope"](None, adapter, "5")
     lines = output.splitlines()
-    assert all(len(line) == 5 for line in lines[:-1])
+    assert len(lines) == 1
+    assert lines[0].startswith("center=")
 
 
 def test_configure_band_scope_wraps_programming(monkeypatch):
@@ -153,6 +138,8 @@ def test_configure_band_scope_sets_width(monkeypatch):
     adapter.configure_band_scope(None, "air")
     assert adapter.band_scope_width == 4803
 
+    adapter.in_program_mode = False
+
     def fake_stream(ser, c=adapter.band_scope_width):
         for i in range(c):
             yield (0, 100.0 + i, 0)
@@ -162,28 +149,9 @@ def test_configure_band_scope_sets_width(monkeypatch):
     commands, _ = build_command_table(adapter, None)
     output = commands["band scope"](None, adapter, "5")
     lines = output.splitlines()
-    assert all(len(line) <= 80 for line in lines)
+    assert len(lines) == 1
+    assert lines[0].startswith("center=")
 
-
-def test_band_scope_output_wrapped(monkeypatch):
-    adapter = BCD325P2Adapter()
-
-    # Set a width larger than the terminal width to trigger wrapping
-    adapter.band_scope_width = 160
-
-    def fake_stream(ser, c=160):
-        for i in range(c):
-            yield (0, 145.0 + 0.1 * i, 0)
-
-    monkeypatch.setattr(adapter, "stream_custom_search", fake_stream)
-
-    commands, _ = build_command_table(adapter, None)
-    output = commands["band scope"](None, adapter, "160")
-    lines = output.splitlines()
-
-    # Output should be wrapped so no line exceeds 80 characters
-    assert len(lines) == 3
-    assert all(len(line) <= 80 for line in lines[:-1])
 
 
 def test_band_scope_no_data(monkeypatch):
@@ -199,74 +167,6 @@ def test_band_scope_no_data(monkeypatch):
 
     assert result == "No band scope data received"
 
-
-def test_band_scope_baseline(monkeypatch):
-    adapter = BCD325P2Adapter()
-    adapter.band_scope_width = 3
-
-    def stream_stub(ser, c=3):
-        yield (10, 100.0, 0)
-        yield (20, 101.0, 0)
-        yield (40, 102.0, 0)
-
-    monkeypatch.setattr(adapter, "stream_custom_search", stream_stub)
-
-    captured = {}
-
-    import utilities.core.command_registry as cr
-
-    def fake_render(pairs, width):
-        captured["pairs"] = pairs
-        return "graph"
-
-    monkeypatch.setattr(cr, "render_band_scope_waterfall", fake_render)
-
-    commands, _ = build_command_table(adapter, None)
-    result = commands["band scope"](None, adapter, "3")
-
-    assert result.splitlines()[0] == "graph"
-    expected = [
-        (100.0, 0.0),
-        (101.0, 10 / 1023.0),
-        (102.0, 30 / 1023.0),
-    ]
-    assert captured["pairs"] == pytest.approx(expected)
-
-
-def test_band_scope_log_scaling(monkeypatch):
-    adapter = BCD325P2Adapter()
-    adapter.band_scope_width = 3
-
-    def stream_stub(ser, c=3):
-        yield (10, 100.0, 0)
-        yield (20, 101.0, 0)
-        yield (40, 102.0, 0)
-
-    monkeypatch.setattr(adapter, "stream_custom_search", stream_stub)
-
-    captured = {}
-    import utilities.core.command_registry as cr
-
-    def fake_render(pairs, width):
-        captured["pairs"] = pairs
-        return "graph"
-
-    monkeypatch.setattr(cr, "render_band_scope_waterfall", fake_render)
-
-    commands, _ = build_command_table(adapter, None)
-    result = commands["band scope"](None, adapter, "3 log")
-
-    assert result.splitlines()[0] == "graph"
-    import math
-
-    baseline = 10
-    max_db = 20 * math.log10(1023 - baseline + 1)
-    expected = [
-        (100.0, 0.0),
-        (101.0, 20 * math.log10(10 + 1) / max_db),
-        (102.0, 20 * math.log10(30 + 1) / max_db),
-    ]
-    assert captured["pairs"] == pytest.approx(expected)
 
 
 def test_band_scope_summary_line(monkeypatch):
@@ -287,6 +187,7 @@ def test_band_scope_summary_line(monkeypatch):
     commands, _ = build_command_table(adapter, None)
     output = commands["band scope"](None, adapter, "3")
     lines = output.splitlines()
+    assert lines[:3] == ["145.0000", "146.0000", "147.0000"]
     assert lines[-1].startswith("center=")
     assert "min=145.000" in lines[-1]
     assert "max=147.000" in lines[-1]
@@ -330,4 +231,6 @@ def test_band_scope_list_hits(monkeypatch):
 
     commands, _ = build_command_table(adapter, None)
     output = commands["band scope"](None, adapter, "list")
-    assert output.splitlines() == ["146.0000", "148.0000"]
+    lines = output.splitlines()
+    assert lines[:2] == ["146.0000", "148.0000"]
+    assert lines[-1].startswith("center=")

--- a/tests/test_custom_search.py
+++ b/tests/test_custom_search.py
@@ -29,8 +29,8 @@ def test_band_scope_command_registered(monkeypatch):
     assert "band scope" in help_text
     output = commands["band scope"](None, adapter, "10")
     lines = output.splitlines()
-    assert len(lines) == 3
-    assert all(len(line) == 5 for line in lines[:-1])
+    assert len(lines) == 1
+    assert lines[0].startswith("center=")
 
 
 def test_band_scope_collects(monkeypatch):

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -30,7 +30,7 @@ from utilities.core.serial_utils import (
 )
 from utilities.io.readline_setup import initialize_readline
 from utilities.log_utils import configure_logging, get_logger
-from utilities.graph_utils import render_rssi_graph, render_band_scope_waterfall
+from utilities.graph_utils import render_rssi_graph
 
 try:
     from utilities.scanner.close_call_logger import record_close_calls
@@ -60,6 +60,5 @@ __all__ = [
     "send_command",
     "wait_for_data",
     "render_rssi_graph",
-    "render_band_scope_waterfall",
     "record_close_calls",
 ]

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -8,11 +8,7 @@ import logging
 import math
 import config
 
-from utilities.graph_utils import (
-    render_rssi_graph,
-    render_band_scope_waterfall,
-    split_output_lines,
-)
+from utilities.graph_utils import render_rssi_graph
 
 
 def build_command_table(adapter, ser):
@@ -211,8 +207,6 @@ def build_command_table(adapter, ser):
                     except ValueError:
                         pass
 
-            width = getattr(adapter_, "band_scope_width", 64) or 64
-
             if getattr(adapter_, "in_program_mode", False):
                 return (
                     "Scanner is in programming mode. "
@@ -221,44 +215,15 @@ def build_command_table(adapter, ser):
 
             records = []
             hits = []
-            baseline = None
             for rssi, freq, _ in adapter_.stream_custom_search(ser_, count):
                 records.append((rssi, freq))
                 if rssi and rssi > 0:
-                    baseline = rssi if baseline is None else min(baseline, rssi)
-                    if list_hits:
-                        hits.append(f"{freq:.4f}")
+                    hits.append(f"{freq:.4f}")
 
             if not records:
                 return "No band scope data received"
 
-            if list_hits:
-                return "\n".join(hits)
-
-            baseline = baseline or 0
-            max_db = (
-                20 * math.log10(1023 - baseline + 1) if log_scale else None
-            )
-
-            pairs = []
-            for rssi, freq in records:
-                if rssi is None:
-                    pairs.append((freq, None))
-                    continue
-                adj = max(0, rssi - baseline)
-                value = adj / 1023.0
-                if log_scale:
-                    value = (
-                        20 * math.log10(adj + 1) / max_db if max_db and adj > 0 else 0.0
-                    )
-                pairs.append((freq, value))
-
-            output = render_band_scope_waterfall(pairs, width)
-
-            if width > 80:
-                output = split_output_lines(output, 80)
-
-            freqs = [f for f, _ in pairs]
+            freqs = [f for _, f in records]
             if freqs:
                 f_min = min(freqs)
                 f_max = max(freqs)
@@ -297,11 +262,11 @@ def build_command_table(adapter, ser):
                 f"step={fmt_span(step)} mod={mod or 'N/A'}"
             )
 
-            return output + "\n" + summary
+            return "\n".join(hits + [summary])
 
         COMMANDS["band scope"] = band_scope
         COMMAND_HELP["band scope"] = (
-            "Stream band scope data. Usage: band scope [record_count] [log|list|hits]"
+            "Stream band scope data. Usage: band scope [record_count]"
         )
 
         logging.debug("Registering 'band sweep' command")

--- a/utilities/graph_utils.py
+++ b/utilities/graph_utils.py
@@ -35,66 +35,6 @@ def render_rssi_graph(pairs):
     return "".join(top) + "\n" + "".join(bottom)
 
 
-def render_band_scope_waterfall(pairs, width=64):
-    """Render band scope results as a waterfall-style graph.
-
-    Parameters
-    ----------
-    pairs : list of tuple
-        ``(frequency, rssi)`` tuples with RSSI normalized between ``0`` and ``1``.
-    width : int, optional
-        Number of frequency bins to divide the data into. Defaults to ``64``.
-
-    Returns
-    -------
-    str
-        Multiple lines of characters where each line represents one sweep.
-    """
-
-    if not pairs or width <= 0:
-        return ""
-
-    freqs = [f for f, _ in pairs]
-    f_min = min(freqs)
-    f_max = max(freqs)
-    if f_max == f_min:
-        f_max += 1e-6
-    bin_size = (f_max - f_min) / float(width)
-
-    rows = []
-    bins = [[0.0, 0] for _ in range(width)]
-    prev_freq = None
-
-    for freq, rssi in pairs:
-        if prev_freq is not None and freq < prev_freq:
-            rows.append(bins)
-            bins = [[0.0, 0] for _ in range(width)]
-        prev_freq = freq
-        idx = int((freq - f_min) / bin_size)
-        if idx >= width:
-            idx = width - 1
-        if rssi is not None:
-            bins[idx][0] += rssi
-            bins[idx][1] += 1
-
-    rows.append(bins)
-
-    lines = []
-    max_level = len(BLOCKS) - 1
-    for row in rows:
-        chars = []
-        for total, count in row:
-            if count == 0:
-                level = 0
-            else:
-                avg = total / count
-                level = max(0, min(max_level, int(round(avg * max_level))))
-            chars.append(BLOCKS[level])
-        lines.append("".join(chars))
-
-    return "\n".join(lines)
-
-
 def split_output_lines(output, width):
     """Wrap each line of ``output`` so no line exceeds ``width`` characters."""
 


### PR DESCRIPTION
## Summary
- simplify band scope command to output a list of hit frequencies
- remove unused waterfall rendering utility and imports
- update CLI help and docs for new behavior
- adjust tests for simplified band scope output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688997c065508324926f593e700d0a49