### PR TITLE
Unify band scope feedback handling

### DIFF
--- a/adapters/uniden/bc125at_adapter.py
+++ b/adapters/uniden/bc125at_adapter.py
@@ -274,17 +274,16 @@ class BC125ATAdapter(UnidenScannerAdapter):
         self.last_step = self._to_mhz(step)
         self.last_mod = mod
 
-        result = None
         with programming_session(self, ser) as ok:
             if not ok:
                 return self.feedback(False, "Failed to enter programming mode")
-            result = self.sweep_band_scope(ser, freq, span, step)
+            self.sweep_band_scope(ser, freq, span, step)
         # Start the band-scope search after leaving programming mode
         try:
             self.start_scanning(ser)
         except Exception as e:  # pragma: no cover - log and proceed
             logger.error(f"Error starting band scope search: {e}")
-        return result
+        return self.feedback(True, "OK")
 
     def sweep_band_scope(self, ser, center_freq, span, step, bandwidth=None):
         """Sweep across a frequency range using quick hold mode."""

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -118,12 +118,13 @@ def test_configure_band_scope_wraps_programming(monkeypatch):
         adapter, "start_scanning", lambda ser: calls.append("START")
     )
 
-    adapter.configure_band_scope(None, "air")
+    result = adapter.configure_band_scope(None, "air")
 
     assert calls[0] == "PRG"
     assert calls[1].startswith("BSP")
     assert calls[2] == "EPG"
     assert calls[-1] == "START"
+    assert result == "OK"
 
 
 def test_configure_band_scope_sets_width(monkeypatch):
@@ -135,8 +136,9 @@ def test_configure_band_scope_sets_width(monkeypatch):
 
     monkeypatch.setattr(adapter.commands["BSP"], "validator", None)
 
-    adapter.configure_band_scope(None, "air")
+    result = adapter.configure_band_scope(None, "air")
     assert adapter.band_scope_width == 4803
+    assert result == "OK"
 
     adapter.in_program_mode = False
 

--- a/tests/test_bc125at_band_scope.py
+++ b/tests/test_bc125at_band_scope.py
@@ -55,11 +55,12 @@ def test_bc125at_configure_band_scope_wraps_programming(monkeypatch):
     monkeypatch.setattr(adapter, "read_rssi", lambda ser: 0)
     monkeypatch.setattr(adapter, "start_scanning", lambda ser: calls.append("START"))
 
-    adapter.configure_band_scope(None, "air")
+    result = adapter.configure_band_scope(None, "air")
 
     assert calls[0] == "PRG"
     assert calls[1] == "EPG"
     assert calls[-1] == "START"
+    assert result == "OK"
 
 
 def test_bc125at_configure_band_scope_sets_width(monkeypatch):
@@ -73,5 +74,6 @@ def test_bc125at_configure_band_scope_sets_width(monkeypatch):
     monkeypatch.setattr(adapter, "read_rssi", lambda ser: 0)
     monkeypatch.setattr(adapter, "start_scanning", lambda ser: None)
 
-    adapter.configure_band_scope(None, "air")
+    result = adapter.configure_band_scope(None, "air")
     assert adapter.band_scope_width == 3362
+    assert result == "OK"


### PR DESCRIPTION
## Summary
- BC125AT adapter: return standard feedback string from `configure_band_scope`
- update unit tests for unified return values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688999ae08f08324842fd631878e00fa