### PR TITLE
Include RSSI values in band scope output

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,12 +186,13 @@ stopping the stream. By default, **1024** records are collected. After the limit
 is reached the command `CSC,OFF` is issued and the final `CSC,OK` response is
 read.
 When called through the CLI's `band scope` command these readings are printed as
-a list of hit frequencies. After all hits a summary line describes the sweep
-parameters. Only results with RSSI above zero are printed:
+a list of hit frequencies with their normalized signal strength. After all hits
+a summary line describes the sweep parameters. Only results with RSSI above zero
+are printed:
 
 ```text
-146.5200
-147.0400
+146.5200, 0.450
+147.0400, 0.610
 center=146.000 min=145.000 max=147.000 span=2M step=0.5M mod=FM
 ```
 

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -189,7 +189,11 @@ def test_band_scope_summary_line(monkeypatch):
     commands, _ = build_command_table(adapter, None)
     output = commands["band scope"](None, adapter, "3")
     lines = output.splitlines()
-    assert lines[:3] == ["145.0000", "146.0000", "147.0000"]
+    assert lines[:3] == [
+        "145.0000, 0.010",
+        "146.0000, 0.020",
+        "147.0000, 0.029",
+    ]
     assert lines[-1].startswith("center=")
     assert "min=145.000" in lines[-1]
     assert "max=147.000" in lines[-1]
@@ -234,7 +238,7 @@ def test_band_scope_list_hits(monkeypatch):
     commands, _ = build_command_table(adapter, None)
     output = commands["band scope"](None, adapter, "list")
     lines = output.splitlines()
-    assert lines[:2] == ["146.0000", "148.0000"]
+    assert lines[:2] == ["146.0000, 0.049", "148.0000, 0.029"]
     assert lines[-1].startswith("center=")
 
 def test_band_scope_respects_preset_range(monkeypatch):
@@ -260,7 +264,7 @@ def test_band_scope_respects_preset_range(monkeypatch):
 
     output = commands["band scope"](None, adapter, "list")
     lines = output.splitlines()
-    hits = [float(h) for h in lines[:-1]]
+    hits = [float(h.split(",")[0]) for h in lines[:-1]]
     assert all(144.0 <= f <= 148.0 for f in hits)
     assert "min=144.000" in lines[-1]
     assert "max=148.000" in lines[-1]

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -218,7 +218,7 @@ def build_command_table(adapter, ser):
             for rssi, freq, _ in adapter_.stream_custom_search(ser_, count):
                 records.append((rssi, freq))
                 if rssi and rssi > 0:
-                    hits.append(f"{freq:.4f}")
+                    hits.append(f"{freq:.4f}, {rssi / 1023.0:.3f}")
 
             if not records:
                 return "No band scope data received"


### PR DESCRIPTION
## Summary
- show normalized RSSI alongside frequency when listing band scope hits
- update tests for the new hit format
- document new example output in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a61a9e378832497186b118a7f84ac