### PR TITLE
Add CSP/CSG setup in band-scope programming

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ name or explicit parameters. The shorter alias `band set` behaves the same.
 ```
 
 After the `BSP` command is sent during `band select`, the scanner now
-automatically enters band-scope search by issuing a scan-start key.
+automatically enters band-scope search by issuing a scan-start key. It also
+programs custom search range 1 using `CSP` and enables only that range with
+`CSG,0111111111` so the scope limits match the selected band.
 If the search is later halted you can resume it with the dedicated
 command:
 

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -277,6 +277,42 @@ class BCD325P2Adapter(UnidenScannerAdapter):
 
                 response = self.send_command(ser, cmd)
                 response_str = ensure_str(response)
+
+                csp_obj = self.commands.get("CSP")
+                if csp_obj:
+                    csp_cmd = csp_obj.set_format.format(
+                        srch_index=1,
+                        name="",
+                        limit_l=int(low_khz),
+                        limit_h=int(high_khz),
+                        stp=step,
+                        mod=mod,
+                        att=0,
+                        dly=0,
+                        rsv="",
+                        hld=0,
+                        lout=0,
+                        c_ch=0,
+                        quick_key=".",
+                        start_key=".",
+                        number_tag="NONE",
+                        agc_analog=0,
+                        agc_digital=0,
+                        p25waiting=0,
+                    )
+                else:
+                    csp_cmd = (
+                        f"CSP,1,,{int(low_khz)},{int(high_khz)},{step},{mod},0,0,,0,0,0,,,.,.,,NONE,0,0,0"
+                    )
+                self.send_command(ser, csp_cmd)
+
+                csg_obj = self.commands.get("CSG")
+                if csg_obj:
+                    csg_cmd = csg_obj.set_format.format(status="0111111111")
+                else:
+                    csg_cmd = "CSG,0111111111"
+                self.send_command(ser, csg_cmd)
+
                 self.band_scope_width = self._calc_band_scope_width(
                     span, bandwidth or step
                 )

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -330,7 +330,7 @@ class BCD325P2Adapter(UnidenScannerAdapter):
                 if csg_obj:
                     csg_cmd = csg_obj.set_format.format(status="0111111111")
                 else:
-                    csg_cmd = "CSG,0111111111"
+                    csg_cmd = f"CSG,{CSG_ENABLE_RANGE_1}"
                 self.send_command(ser, csg_cmd)
 
                 self.band_scope_width = self._calc_band_scope_width(

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -301,8 +301,28 @@ class BCD325P2Adapter(UnidenScannerAdapter):
                         p25waiting=0,
                     )
                 else:
+                    # Define named constants for CSP command parameters
+                    SRCH_INDEX = 1
+                    NAME = ""
+                    ATT = 0
+                    DLY = 0
+                    RSV = ""
+                    HLD = 0
+                    LOUT = 0
+                    C_CH = 0
+                    QUICK_KEY = "."
+                    START_KEY = "."
+                    NUMBER_TAG = "NONE"
+                    AGC_ANALOG = 0
+                    AGC_DIGITAL = 0
+                    P25WAITING = 0
+
+                    # Construct the fallback CSP command string
                     csp_cmd = (
-                        f"CSP,1,,{int(low_khz)},{int(high_khz)},{step},{mod},0,0,,0,0,0,,,.,.,,NONE,0,0,0"
+                        f"CSP,{SRCH_INDEX},{NAME},{int(low_khz)},{int(high_khz)},"
+                        f"{step},{mod},{ATT},{DLY},{RSV},{HLD},{LOUT},{C_CH},"
+                        f"{QUICK_KEY},{START_KEY},{NUMBER_TAG},{AGC_ANALOG},"
+                        f"{AGC_DIGITAL},{P25WAITING}"
                     )
                 self.send_command(ser, csp_cmd)
 


### PR DESCRIPTION
## Summary
- extend BCD325P2 band scope programming to set custom search range 1
- update tests for new command sequence and validate CSP values
- document CSP/CSG usage in band-select

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a7f096c8c832484f6672322a7ed37