### PR TITLE
Add debug logging option to custom search stream

### DIFF
--- a/adapters/uniden/bcd325p2/custom_search.py
+++ b/adapters/uniden/bcd325p2/custom_search.py
@@ -11,7 +11,7 @@ from utilities.core.serial_utils import (
 logger = logging.getLogger(__name__)
 
 
-def stream_custom_search(self, ser, record_count=1024):
+def stream_custom_search(self, ser, record_count=1024, debug=False):
     """Stream custom search results using the CSC command.
 
     Parameters
@@ -21,6 +21,9 @@ def stream_custom_search(self, ser, record_count=1024):
     record_count : int, optional
         Number of result lines to read before stopping the stream.
         Defaults to 1024.
+    debug : bool, optional
+        If ``True``, log each raw line read from the scanner before
+        parsing it. Defaults to ``False``.
 
     Yields
     ------
@@ -35,6 +38,8 @@ def stream_custom_search(self, ser, record_count=1024):
             if not wait_for_data(ser, max_wait=0.5):
                 break
             line = read_response(ser, timeout=1.0)
+            if debug:
+                logger.debug(line)
             if not line:
                 break
             if not line.startswith("CSC,"):
@@ -54,6 +59,8 @@ def stream_custom_search(self, ser, record_count=1024):
                     logger.debug(f"Malformed line: {line}")
         # Stop streaming and read final OK
         send_command(ser, "CSC,OFF", delay=0)
-        read_response(ser, timeout=1.0)
+        line = read_response(ser, timeout=1.0)
+        if debug:
+            logger.debug(line)
     except Exception as e:
         logger.error(f"Error during custom search stream: {e}")

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -91,7 +91,7 @@ def test_band_scope_auto_width(monkeypatch):
     adapter.sweep_band_scope(None, "146M", "2M", "0.5M", "0.5M")
     assert adapter.band_scope_width == 5
 
-    def fake_stream(ser, c=5):
+    def fake_stream(ser, c=5, debug=False):
         for i in range(c):
             yield (0, 145.0 + 0.5 * i, 0)
 
@@ -168,7 +168,7 @@ def test_configure_band_scope_sets_width(monkeypatch):
 
     adapter.in_program_mode = False
 
-    def fake_stream(ser, c=adapter.band_scope_width):
+    def fake_stream(ser, c=adapter.band_scope_width, debug=False):
         for i in range(c):
             yield (0, 100.0 + i, 0)
 
@@ -185,7 +185,7 @@ def test_configure_band_scope_sets_width(monkeypatch):
 def test_band_scope_no_data(monkeypatch):
     adapter = BCD325P2Adapter()
 
-    def empty_stream(ser, c=5):
+    def empty_stream(ser, c=5, debug=False):
         yield from []
 
     monkeypatch.setattr(adapter, "stream_custom_search", empty_stream)
@@ -205,7 +205,7 @@ def test_band_scope_summary_line(monkeypatch):
     adapter.last_step = 0.5
     adapter.last_mod = "FM"
 
-    def stream_stub(ser, c=3):
+    def stream_stub(ser, c=3, debug=False):
         yield (10, 145.0, 0)
         yield (20, 146.0, 0)
         yield (30, 147.0, 0)
@@ -234,7 +234,7 @@ def test_band_scope_in_program_mode(monkeypatch):
 
     called = []
 
-    def stream_stub(ser, c=3):
+    def stream_stub(ser, c=3, debug=False):
         called.append(True)
         yield (10, 145.0, 0)
 
@@ -253,7 +253,7 @@ def test_band_scope_in_program_mode(monkeypatch):
 def test_band_scope_list_hits(monkeypatch):
     adapter = BCD325P2Adapter()
 
-    def stream_stub(ser, c=1024):
+    def stream_stub(ser, c=1024, debug=False):
         yield (0, 145.0, 0)
         yield (50, 146.0, 1)
         yield (0, 147.0, 0)
@@ -278,7 +278,7 @@ def test_band_scope_respects_preset_range(monkeypatch):
     commands["band select"](None, adapter, "ham2m")
     adapter.in_program_mode = False
 
-    def stream_stub(ser, c=1024):
+    def stream_stub(ser, c=1024, debug=False):
         SIGNAL_LOW = 10  # Low signal strength
         SIGNAL_MEDIUM = 20  # Medium signal strength
         SIGNAL_HIGH = 30  # High signal strength

--- a/tests/test_band_sweep.py
+++ b/tests/test_band_sweep.py
@@ -23,7 +23,7 @@ def test_band_sweep_registered_and_output(monkeypatch):
         (256, 163.55, 0),
     ]
 
-    def fake_stream(ser, count=1024):
+    def fake_stream(ser, count=1024, debug=False):
         for rssi, freq, sql in data[:count]:
             yield rssi, freq, sql
 

--- a/tests/test_custom_search.py
+++ b/tests/test_custom_search.py
@@ -16,7 +16,7 @@ from utilities.core.command_registry import build_command_table  # noqa: E402
 
 def test_band_scope_command_registered(monkeypatch):
     adapter = BCD325P2Adapter()
-    def fake_stream(ser, c=1024):
+    def fake_stream(ser, c=1024, debug=False):
         for i in range(int(c)):
             yield (0, 100.0 + i % 5, 0)
 

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -214,7 +214,10 @@ def build_command_table(adapter, ser):
 
             records = []
             hits = []
-            for rssi, freq, _ in adapter_.stream_custom_search(ser_, count):
+            debug_mode = logging.getLogger().isEnabledFor(logging.DEBUG)
+            for rssi, freq, _ in adapter_.stream_custom_search(
+                ser_, count, debug=debug_mode
+            ):
                 records.append((rssi, freq))
                 if rssi and rssi > 0:
                     hits.append(f"{freq:.4f}, {rssi / MAX_RSSI:.3f}")
@@ -274,7 +277,10 @@ def build_command_table(adapter, ser):
             parts = arg.split()
             count = int(parts[0]) if parts else 1024
             output_lines = []
-            for rssi, freq, _ in adapter_.stream_custom_search(ser_, count):
+            debug_mode = logging.getLogger().isEnabledFor(logging.DEBUG)
+            for rssi, freq, _ in adapter_.stream_custom_search(
+                ser_, count, debug=debug_mode
+            ):
                 if rssi is None or freq is None:
                     continue
                 output_lines.append(f"{freq:.4f}, {rssi / MAX_RSSI:.3f}")


### PR DESCRIPTION
## Summary
- extend `stream_custom_search` with `debug` flag to log raw lines
- update command registry to pass debug lines when logging level is DEBUG
- adjust tests for the new parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a867f6c308324bf32bee71ba5a9f0