### PR TITLE
Clarify frequency docs for BCD325P2

### DIFF
--- a/adapters/uniden/bcd325p2/channel.py
+++ b/adapters/uniden/bcd325p2/channel.py
@@ -38,7 +38,8 @@ def write_channel_info(
         ser: Serial connection to the scanner.
         index: Channel index.
         name: Channel name.
-        freq_khz: Frequency in kHz.
+        freq_khz: Frequency value as an eight-digit number in
+            100‑Hz increments.
         mod: Modulation type.
         ctcss: CTCSS tone.
         delay: Delay setting.

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -368,7 +368,11 @@ class BCD325P2Adapter(UnidenScannerAdapter):
         return float(value_str)
 
     def _to_khz(self, value):
-        """Convert a numeric string with optional unit suffix to kHz."""
+        """Convert a numeric string with optional unit suffix to kHz.
+
+        Bare integer strings are interpreted as eight-digit frequency
+        values representing 100‑Hz increments.
+        """
         value_str = str(value).strip().lower()
 
         if value_str.isdigit():
@@ -390,8 +394,8 @@ class BCD325P2Adapter(UnidenScannerAdapter):
     def _calc_band_scope_width(self, span, bandwidth):
         """Return the number of sweep bins from span and bandwidth values.
 
-        Bare integers are interpreted as hundredths of a kilohertz
-        (e.g. ``833`` becomes ``8.33 kHz``).
+        Bare integers are interpreted as eight-digit values in 100‑Hz
+        increments (e.g. ``833`` becomes ``8.33`` kHz).
         """
         try:
             span_mhz = self._to_mhz(span)

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -395,7 +395,7 @@ class BCD325P2Adapter(UnidenScannerAdapter):
         """Return the number of sweep bins from span and bandwidth values.
 
         Bare integers are interpreted as eight-digit values in 100‑Hz
-        increments (e.g. ``833`` becomes ``8.33`` kHz).
+        increments (e.g. ``08330000`` becomes ``833.000 kHz``).
         """
         try:
             span_mhz = self._to_mhz(span)


### PR DESCRIPTION
## Summary
- adjust BCD325P2 channel frequency docstring to note 8‑digit 100‑Hz values
- document numeric frequency format in helper methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a9af927748324b10b6de01b049d5f