### PR TITLE
Fix custom search range units

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,9 @@ name or explicit parameters. The shorter alias `band set` behaves the same.
 After the `BSP` command is sent during `band select`, the scanner now
 automatically enters band-scope search by issuing a scan-start key. It also
 programs custom search range 1 using `CSP` and enables only that range with
-`CSG,0111111111` so the scope limits match the selected band.
+`CSG,0111111111` so the scope limits match the selected band. The `CSP`
+command uses the preset limits in 100‑Hz units (e.g. `01080000` for 108 MHz)
+to align with the scanner's expected format.
 If the search is later halted you can resume it with the dedicated
 command:
 

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -211,11 +211,13 @@ class BCD325P2Adapter(UnidenScannerAdapter):
         except ValueError as e:
             return self.feedback(False, str(e))
 
-        low_khz = self._to_khz(low)
-        high_khz = self._to_khz(high)
-        span_mhz = (high_khz - low_khz) / 1000.0
-        center_khz = (low_khz + high_khz) / 2.0
-        freq = f"{int(round(center_khz * 10)):08d}"
+        low_mhz = self._to_mhz(low)
+        high_mhz = self._to_mhz(high)
+        span_mhz = high_mhz - low_mhz
+        center_mhz = (low_mhz + high_mhz) / 2.0
+        freq = f"{int(round(center_mhz * 10000)):08d}"
+        low_lim = int(round(low_mhz * 10000))
+        high_lim = int(round(high_mhz * 10000))
 
         allowed_spans = [
             0.2,
@@ -252,7 +254,7 @@ class BCD325P2Adapter(UnidenScannerAdapter):
         max_hold = 0
         bandwidth = None
 
-        self.last_center = center_khz / 1000.0
+        self.last_center = center_mhz
         self.last_span = span_val
         self.last_step = self._to_mhz(step)
         self.last_mod = mod
@@ -283,8 +285,8 @@ class BCD325P2Adapter(UnidenScannerAdapter):
                     csp_cmd = csp_obj.set_format.format(
                         srch_index=1,
                         name="",
-                        limit_l=int(low_khz),
-                        limit_h=int(high_khz),
+                        limit_l=low_lim,
+                        limit_h=high_lim,
                         stp=step,
                         mod=mod,
                         att=0,
@@ -319,7 +321,7 @@ class BCD325P2Adapter(UnidenScannerAdapter):
 
                     # Construct the fallback CSP command string
                     csp_cmd = (
-                        f"CSP,{SRCH_INDEX},{NAME},{int(low_khz)},{int(high_khz)},"
+                        f"CSP,{SRCH_INDEX},{NAME},{low_lim},{high_lim},"
                         f"{step},{mod},{ATT},{DLY},{RSV},{HLD},{LOUT},{C_CH},"
                         f"{QUICK_KEY},{START_KEY},{NUMBER_TAG},{AGC_ANALOG},"
                         f"{AGC_DIGITAL},{P25WAITING}"

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -169,8 +169,8 @@ def test_configure_band_scope_csp_format(monkeypatch):
     adapter.configure_band_scope(None, "air")
 
     csp_cmd = next(cmd for cmd in calls if cmd.startswith("CSP"))
-    assert ",108000," in csp_cmd
-    assert ",136000," in csp_cmd
+    assert ",1080000," in csp_cmd
+    assert ",1360000," in csp_cmd
     assert ",833," in csp_cmd
 
 


### PR DESCRIPTION
## Summary
- convert band scope limits to 100‑Hz units when configuring custom search ranges
- document 100‑Hz unit usage for CSP in README
- update tests for new CSP format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aea88be088324984319fb1ce787cd