### PR TITLE
Add common scanner unit frequency constants

### DIFF
--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -53,6 +53,7 @@ from adapters.uniden.common.core import (
     feedback,
     send_command,
 )
+from adapters.uniden.common import SCANNER_UNITS_PER_MHZ
 from adapters.uniden.common.programming import (
     enter_programming_mode,
     exit_programming_mode,
@@ -215,9 +216,9 @@ class BCD325P2Adapter(UnidenScannerAdapter):
         high_mhz = self._to_mhz(high)
         span_mhz = high_mhz - low_mhz
         center_mhz = (low_mhz + high_mhz) / 2.0
-        freq = f"{int(round(center_mhz * HZ_PER_100HZ_UNIT)):08d}"
-        low_lim = int(round(low_mhz * HZ_PER_100HZ_UNIT))
-        high_lim = int(round(high_mhz * HZ_PER_100HZ_UNIT))
+        freq = f"{int(round(center_mhz * SCANNER_UNITS_PER_MHZ)):08d}"
+        low_lim = int(round(low_mhz * SCANNER_UNITS_PER_MHZ))
+        high_lim = int(round(high_mhz * SCANNER_UNITS_PER_MHZ))
 
         allowed_spans = [
             0.2,

--- a/adapters/uniden/common/__init__.py
+++ b/adapters/uniden/common/__init__.py
@@ -1,1 +1,5 @@
 """Common functions for Uniden scanner adapters."""
+
+from .constants import HZ_PER_SCANNER_UNIT, SCANNER_UNITS_PER_MHZ
+
+__all__ = ["HZ_PER_SCANNER_UNIT", "SCANNER_UNITS_PER_MHZ"]

--- a/adapters/uniden/common/constants.py
+++ b/adapters/uniden/common/constants.py
@@ -1,0 +1,9 @@
+"""Common constants for Uniden scanner adapters."""
+
+# Number of Hertz represented by a single scanner unit
+HZ_PER_SCANNER_UNIT = 100
+
+# Number of scanner units in one megahertz
+SCANNER_UNITS_PER_MHZ = 1_000_000 // HZ_PER_SCANNER_UNIT
+
+__all__ = ["HZ_PER_SCANNER_UNIT", "SCANNER_UNITS_PER_MHZ"]


### PR DESCRIPTION
## Summary
- add constants for converting between Hz, MHz and scanner units
- export these constants for easier importing
- use the shared SCANNER_UNITS_PER_MHZ in BCD325P2 adapter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c169c0ccc83248c5672be52fca100