### PR TITLE
Use shared constants for BC125AT frequencies

### DIFF
--- a/adapters/uniden/bc125at/frequency.py
+++ b/adapters/uniden/bc125at/frequency.py
@@ -6,6 +6,11 @@ Contains functions for reading and setting frequencies.
 
 import time
 
+from adapters.uniden.common.constants import (
+    HZ_PER_MHZ,
+    HZ_PER_SCANNER_UNIT,
+    SCANNER_UNITS_PER_MHZ,
+)
 from adapters.uniden.common.core import ensure_str
 from utilities.scanner.backend import send_command
 
@@ -25,7 +30,7 @@ def read_frequency(self, ser):
 
         parts = response_str.strip().split(",")
         if len(parts) == 3 and parts[0] == "PWR":
-            freq_mhz = (int(parts[2]) * 100) / 1_000_000
+            freq_mhz = (int(parts[2]) * HZ_PER_SCANNER_UNIT) / HZ_PER_MHZ
             return self.feedback(True, f"Frequency: {freq_mhz} MHz")
         return self.feedback(False, f"Unexpected response: {response_str}")
     except Exception as e:
@@ -80,7 +85,7 @@ def enter_quick_frequency_hold(self, ser, freq_mhz):
 
         parts = response_str.strip().split(",")
         if len(parts) == 3 and parts[0] == "PWR":
-            actual_freq = int(parts[2]) / 10000.0
+            actual_freq = int(parts[2]) / SCANNER_UNITS_PER_MHZ
             if abs(actual_freq - freq_mhz) < 0.005:
                 return self.feedback(
                     True,

--- a/adapters/uniden/common/constants.py
+++ b/adapters/uniden/common/constants.py
@@ -1,9 +1,12 @@
 """Common constants for Uniden scanner adapters."""
 
+# Number of Hertz in one megahertz
+HZ_PER_MHZ = 1_000_000
+
 # Number of Hertz represented by a single scanner unit
 HZ_PER_SCANNER_UNIT = 100
 
 # Number of scanner units in one megahertz
-SCANNER_UNITS_PER_MHZ = 1_000_000 // HZ_PER_SCANNER_UNIT
+SCANNER_UNITS_PER_MHZ = HZ_PER_MHZ // HZ_PER_SCANNER_UNIT
 
-__all__ = ["HZ_PER_SCANNER_UNIT", "SCANNER_UNITS_PER_MHZ"]
+__all__ = ["HZ_PER_MHZ", "HZ_PER_SCANNER_UNIT", "SCANNER_UNITS_PER_MHZ"]


### PR DESCRIPTION
## Summary
- add `HZ_PER_MHZ` constant to the Uniden common constants module
- use shared constants for frequency conversions in BC125AT adapter

## Testing
- `python -m isort adapters/uniden/common/constants.py adapters/uniden/bc125at/frequency.py`
- `python -m black adapters/uniden/common/constants.py adapters/uniden/bc125at/frequency.py`
- `flake8 adapters/uniden/common/constants.py adapters/uniden/bc125at/frequency.py`
- `pytest`
- `pre-commit run --files adapters/uniden/common/constants.py adapters/uniden/bc125at/frequency.py` *(fails: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688c1b3f18748324a257593862b5af04