### PR TITLE
Reorder imports for BCD325P2 frequency module

### DIFF
--- a/adapters/uniden/bcd325p2/frequency.py
+++ b/adapters/uniden/bcd325p2/frequency.py
@@ -4,9 +4,9 @@ Frequency-related functions for the BCD325P2 scanner.
 Contains functions for reading and setting frequencies.
 """
 
+from decimal import Decimal
 import time
 
-from decimal import Decimal
 from adapters.uniden.common.constants import (
     HZ_PER_MHZ,
     HZ_PER_SCANNER_UNIT,


### PR DESCRIPTION
## Summary
- Reordered imports in `frequency` to place the `Decimal` import near the top

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c291ba8c083248935ee1fdccf9abd