### PR TITLE
Remove duplicate help prompt

### DIFF
--- a/utilities/command/loop.py
+++ b/utilities/command/loop.py
@@ -33,7 +33,7 @@ def main_loop(connection_manager, adapter=None, ser=None, commands=None, command
         Whether to use machine-friendly output. Default ``False``.
     """
     if not machine_mode:
-        print("Type 'help' for a list of commands.\n")
+        print("Type 'help' to display the help menu.\n")
     else:
         print("STATUS:INFO|MESSAGE:Scanner_ready")
 

--- a/utilities/scanner/manager.py
+++ b/utilities/scanner/manager.py
@@ -276,7 +276,6 @@ def detect_and_connect_scanner(machine_mode=False):
             )
         else:
             print(f"Connected to {port} ({scanner_model}) [ID {conn_id}]")
-            print("Type 'help' for available commands.")
 
         return conn_id, ser, adapter, commands, command_help
 


### PR DESCRIPTION
## Summary
- Ensure help prompt is only emitted once by removing redundant print in the scanner manager
- Clarify startup message about accessing the help menu

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688cef406b908324aa12c9c00ffaadf2