### PR TITLE
Rename Controlling Scanner category to Scanner Control

### DIFF
--- a/utilities/command/help_utils.py
+++ b/utilities/command/help_utils.py
@@ -95,7 +95,7 @@ def show_help(commands, command_help, command="", adapter=None):
             "set backlight",
             "set contrast",
         ],
-        "Controlling Scanner": [
+        "Scanner Control": [
             "hold frequency",
             "send",
             "send key",
@@ -137,7 +137,7 @@ def show_help(commands, command_help, command="", adapter=None):
             "Set Commands": [
                 cmd for cmd in sorted(commands) if cmd.startswith("set ")
             ],
-            "Controlling Scanner": [
+            "Scanner Control": [
                 cmd
                 for cmd in sorted(commands)
                 if (
@@ -156,11 +156,11 @@ def show_help(commands, command_help, command="", adapter=None):
             ],
         }
 
-        # Ensure Controlling Scanner commands are always displayed if they exist
-        if not general_commands["Controlling Scanner"]:
-            general_commands["Controlling Scanner"] = [
+        # Ensure Scanner Control commands are always displayed if they exist
+        if not general_commands["Scanner Control"]:
+            general_commands["Scanner Control"] = [
                 cmd
-                for cmd in standard_commands["Controlling Scanner"]
+                for cmd in standard_commands["Scanner Control"]
                 if cmd in commands
             ]
     else:

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -146,8 +146,8 @@ def build_command_table(adapter, ser):
         )
         COMMAND_HELP["get signal"] = "Get the signal strength meter reading."
 
-    # -- Controlling Scanner commands --
-    # Always register essential controlling scanner commands
+    # -- Scanner Control commands --
+    # Always register essential scanner control commands
 
     # Send key
     if hasattr(adapter, 'send_key'):


### PR DESCRIPTION
## Summary
- rename "Controlling Scanner" category to "Scanner Control" in help utilities
- adjust general command grouping to use new category name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688cfb469bc88324abe008dd7c081d51