### PR TITLE
chore: remove unused logger from help utils

### DIFF
--- a/utilities/command/help_utils.py
+++ b/utilities/command/help_utils.py
@@ -5,14 +5,11 @@ This module contains functions for displaying help information
 about available commands and features.
 """
 
-import logging
 from textwrap import dedent
 
 from utilities.command.help_topics import get_extended_help
 
 OTHER_COMMANDS = ["help", "list", "connect", "use", "close", "switch", "exit"]
-
-logger = logging.getLogger(__name__)
 
 
 def show_help(commands, command_help, command="", adapter=None):


### PR DESCRIPTION
## Summary
- drop unused logging import and logger from `help_utils`

## Testing
- `flake8 --ignore=E501,W503 utilities/command/help_utils.py`
- `isort --check-only utilities/command/help_utils.py`
- `black --check utilities/command/help_utils.py`
- `pytest tests/test_help_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688cfc5967f483248df9556ab2bb3af9