### PR TITLE
Implement sweep-based band scope command

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,15 +184,16 @@ command:
 ### Band Scope Streaming
 
 Band scope status can be streamed using the `CSC` command. When activated the
-scanner outputs lines of the form `CSC,<RSSI>,<FRQ>,<SQL>` for each hit.
-The controller now gathers a configurable number of these records before
-stopping the stream. By default, **1024** records are collected. After the limit
-is reached the command `CSC,OFF` is issued and the final `CSC,OK` response is
-read.
-When called through the CLI's `band scope` command these readings are printed as
-a list of hit frequencies with their normalized signal strength. After all hits
-a summary line describes the sweep parameters. Only results with RSSI above zero
-are printed:
+scanner outputs lines of the form `CSC,<RSSI>,<FRQ>,<SQL>` for each hit. The
+controller now processes data in **sweeps**. Each sweep gathers
+`band_scope_width` records (falling back to 1024 if that width is unknown). The
+CLI's `band scope` command performs one sweep by default; providing a number runs
+that many sweeps. Before streaming, the total record count is calculated as
+`band_scope_width * sweeps`. After the final record the command `CSC,OFF` is
+issued and the final `CSC,OK` response is read.
+When called through the CLI these readings are printed as a list of hit
+frequencies with their normalized signal strength. After all hits a summary line
+describes the sweep parameters. Only results with RSSI above zero are printed:
 
 ```text
 146.5200, 0.450
@@ -208,7 +209,12 @@ printed contains the frequency in megahertz and the normalized RSSI level:
 ```
 
 For example: `162.5500, 0.450`. This format is consistent in both human and
-machine modes and is convenient for logging or further processing.
+machine modes and is convenient for logging or further processing. Use the
+optional `list` or `hits` argument to show only channels with activity:
+
+```text
+> band scope [sweeps] [list|hits]
+```
 
 ### Close Call Logging
 

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -112,7 +112,10 @@ def test_band_scope_auto_width(monkeypatch):
     adapter.sweep_band_scope(None, "146M", "2M", "0.5M", "0.5M")
     assert adapter.band_scope_width == 5
 
+    counts = []
+
     def fake_stream(ser, c=5, debug=False):
+        counts.append(c)
         for i in range(c):
             yield (0, 145.0 + 0.5 * i, 0)
 
@@ -123,6 +126,7 @@ def test_band_scope_auto_width(monkeypatch):
     lines = output.splitlines()
     assert len(lines) == 1
     assert lines[0].startswith("center=")
+    assert counts[0] == adapter.band_scope_width * 5
 
 
 def test_configure_band_scope_wraps_programming(monkeypatch):
@@ -224,7 +228,10 @@ def test_band_scope_summary_line(monkeypatch):
     adapter.last_step = 0.5
     adapter.last_mod = "FM"
 
+    counts = []
+
     def stream_stub(ser, c=3, debug=False):
+        counts.append(c)
         yield (10, 145.0, 0)
         yield (20, 146.0, 0)
         yield (30, 147.0, 0)
@@ -245,6 +252,7 @@ def test_band_scope_summary_line(monkeypatch):
     assert "span=2M" in lines[-1]
     assert "step=500k" in lines[-1]
     assert "mod=FM" in lines[-1]
+    assert counts[0] == adapter.band_scope_width * 3
 
 
 def test_band_scope_in_program_mode(monkeypatch):
@@ -272,7 +280,10 @@ def test_band_scope_in_program_mode(monkeypatch):
 def test_band_scope_list_hits(monkeypatch):
     adapter = BCD325P2Adapter()
 
+    counts = []
+
     def stream_stub(ser, c=1024, debug=False):
+        counts.append(c)
         yield (0, 145.0, 0)
         yield (50, 146.0, 1)
         yield (0, 147.0, 0)
@@ -285,6 +296,7 @@ def test_band_scope_list_hits(monkeypatch):
     lines = output.splitlines()
     assert lines[:2] == ["146.0000, 0.049", "148.0000, 0.029"]
     assert lines[-1].startswith("center=")
+    assert counts[0] == 1024
 
 
 def test_band_scope_respects_preset_range(monkeypatch):

--- a/tests/test_custom_search.py
+++ b/tests/test_custom_search.py
@@ -16,7 +16,10 @@ from utilities.core.command_registry import build_command_table  # noqa: E402
 
 def test_band_scope_command_registered(monkeypatch):
     adapter = BCD325P2Adapter()
+    counts = []
+
     def fake_stream(ser, c=1024, debug=False):
+        counts.append(c)
         for i in range(int(c)):
             yield (0, 100.0 + i % 5, 0)
 
@@ -31,6 +34,7 @@ def test_band_scope_command_registered(monkeypatch):
     lines = output.splitlines()
     assert len(lines) == 1
     assert lines[0].startswith("center=")
+    assert counts[0] == adapter.band_scope_width * 10
 
 
 def test_band_scope_collects(monkeypatch):

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -195,14 +195,14 @@ def build_command_table(adapter, ser):
 
         def band_scope(ser_, adapter_, arg=""):
             parts = arg.split()
-            count = 1024
+            sweep_count = 1
             list_hits = False
             for part in parts:
                 if part.lower() in ("list", "hits"):
                     list_hits = True
                 else:
                     try:
-                        count = int(part)
+                        sweep_count = int(part)
                     except ValueError:
                         pass
 
@@ -212,11 +212,14 @@ def build_command_table(adapter, ser):
                     "Run 'send EPG' then 'band scope start'."
                 )
 
+            width = getattr(adapter_, "band_scope_width", None) or 1024
+            record_count = width * sweep_count
+
             records = []
             hits = []
             debug_mode = logging.getLogger().isEnabledFor(logging.DEBUG)
             for rssi, freq, _ in adapter_.stream_custom_search(
-                ser_, count, debug=debug_mode
+                ser_, record_count, debug=debug_mode
             ):
                 records.append((rssi, freq))
                 if rssi and rssi > 0:
@@ -268,7 +271,7 @@ def build_command_table(adapter, ser):
 
         COMMANDS["band scope"] = band_scope
         COMMAND_HELP["band scope"] = (
-            "Stream band scope data. Usage: band scope [record_count]"
+            "Stream band scope data. Usage: band scope [sweeps] [list|hits]"
         )
 
         logging.debug("Registering 'band sweep' command")


### PR DESCRIPTION
## Summary
- Treat numeric argument to `band scope` as sweep count and derive total records from adapter `band_scope_width` with sensible fallback
- Allow optional `list`/`hits` flag, update help text, and document sweep behavior in README
- Adjust tests to verify sweep-based record counting

## Testing
- `pre-commit run --files utilities/core/command_registry.py tests/test_band_scope.py tests/test_custom_search.py README.md` *(failed: unable to access https://github.com/pre-commit/pre-commit-hooks/)*
- `pytest tests/test_band_scope.py tests/test_custom_search.py tests/test_bc125at_band_scope.py`


------
https://chatgpt.com/codex/tasks/task_e_688d02d923e48324bf0aaed1597a88d3