### PR TITLE
Remove obsolete band scope start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,12 +174,6 @@ programs custom search range 1 using `CSP` and enables only that range with
 `CSG,0111111111` so the scope limits match the selected band. The `CSP`
 command uses the preset limits in 100‑Hz units (e.g. `01080000` for 108 MHz)
 to align with the scanner's expected format.
-If the search is later halted you can resume it with the dedicated
-command:
-
-```text
-> band scope start
-```
 
 ### Band Scope Streaming
 

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -272,7 +272,7 @@ def test_band_scope_in_program_mode(monkeypatch):
 
     assert (
         result
-        == "Scanner is in programming mode. Run 'send EPG' then 'band scope start'."
+        == "Scanner is in programming mode. Run 'send EPG' then rerun 'band scope'."
     )
     assert not called
 

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -25,18 +25,12 @@ def test_scan_start_stop_registered(monkeypatch):
 
     assert "scan start" in commands
     assert "scan stop" in commands
-    assert "band scope start" in commands
     assert help_text["scan start"] == "Start scanner scanning process."
     assert help_text["scan stop"] == "Stop scanner scanning process."
-    assert (
-        help_text["band scope start"]
-        == "Begin band-scope search using current settings."
-    )
 
     # Ensure commands use adapter methods
     assert commands["scan start"](None, adapter) == "KEY:S"
     assert commands["scan stop"](None, adapter) == "KEY:H"
-    assert commands["band scope start"](None, adapter) == "KEY:S"
 
 
 def test_bsp_and_bsv_commands_present(monkeypatch):

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -209,7 +209,7 @@ def build_command_table(adapter, ser):
             if getattr(adapter_, "in_program_mode", False):
                 return (
                     "Scanner is in programming mode. "
-                    "Run 'send EPG' then 'band scope start'."
+                    "Run 'send EPG' then rerun 'band scope'."
                 )
 
             width = getattr(adapter_, "band_scope_width", None) or 1024
@@ -408,13 +408,6 @@ def build_command_table(adapter, ser):
             ser_
         )
         COMMAND_HELP["scan start"] = "Start scanner scanning process."
-        logging.debug("Registering 'band scope start' command")
-        COMMANDS["band scope start"] = lambda ser_, adapter_: adapter_.start_scanning(
-            ser_
-        )
-        COMMAND_HELP["band scope start"] = (
-            "Begin band-scope search using current settings."
-        )
     else:
         logging.debug("Registering placeholder 'scan start' command")
         COMMANDS["scan start"] = lambda ser_, adapter_: (
@@ -423,13 +416,6 @@ def build_command_table(adapter, ser):
         COMMAND_HELP["scan start"] = (
             "Start scanner scanning process. "
             "(Not available for this scanner model)"
-        )
-        logging.debug("Registering placeholder 'band scope start' command")
-        COMMANDS["band scope start"] = lambda ser_, adapter_: (
-            "Command 'band scope start' not supported on this scanner model"
-        )
-        COMMAND_HELP["band scope start"] = (
-            "Begin band-scope search. (Not available for this scanner model)"
         )
 
     if hasattr(adapter, 'stop_scanning'):


### PR DESCRIPTION
## Summary
- drop `band scope start` command and placeholder registration
- advise rerunning `band scope` after `send EPG` if in programming mode
- clean up tests and docs referencing `band scope start`

## Testing
- `pytest`
- `pre-commit run --files README.md tests/test_band_scope.py tests/test_command_registry.py utilities/core/command_registry.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'), stderr: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688d05d5fcb08324bbbae3f2c2901b30