### PR TITLE
Add preset handling to band scope command

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ Band scope status can be streamed using the `CSC` command. When activated the
 scanner outputs lines of the form `CSC,<RSSI>,<FRQ>,<SQL>` for each hit. The
 controller now processes data in **sweeps**. Each sweep gathers
 `band_scope_width` records (falling back to 1024 if that width is unknown). The
-CLI's `band scope` command performs one sweep by default; providing a number runs
-that many sweeps. Before streaming, the total record count is calculated as
-`band_scope_width * sweeps`. After the final record the command `CSC,OFF` is
-issued and the final `CSC,OK` response is read.
+CLI's `band scope` command takes a preset name followed by an optional sweep
+count; providing a number runs that many sweeps. Before streaming, the total
+record count is calculated as `band_scope_width * sweeps`. After the final record
+the command `CSC,OFF` is issued and the final `CSC,OK` response is read.
 When called through the CLI these readings are printed as a list of hit
 frequencies with their normalized signal strength. After all hits a summary line
 describes the sweep parameters. Only results with RSSI above zero are printed:
@@ -207,7 +207,7 @@ machine modes and is convenient for logging or further processing. Use the
 optional `list` or `hits` argument to show only channels with activity:
 
 ```text
-> band scope [sweeps] [list|hits]
+> band scope <preset> [sweeps] [list|hits]
 ```
 
 ### Close Call Logging

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -299,6 +299,54 @@ def test_band_scope_list_hits(monkeypatch):
     assert counts[0] == 1024
 
 
+def test_band_scope_preset_invocation(monkeypatch):
+    adapter = BCD325P2Adapter()
+
+    calls = {}
+
+    def configure_stub(ser, preset):
+        calls["preset"] = preset
+        adapter.band_scope_width = 5
+        return "OK"
+
+    def stream_stub(ser, c, debug=False):
+        calls["count"] = c
+        yield (10, 100.0, 0)
+
+    monkeypatch.setattr(adapter, "configure_band_scope", configure_stub)
+    monkeypatch.setattr(adapter, "stream_custom_search", stream_stub)
+
+    commands, _ = build_command_table(adapter, None)
+    commands["band scope"](None, adapter, "air")
+
+    assert calls["preset"] == "air"
+    assert calls["count"] == adapter.band_scope_width
+
+
+def test_band_scope_preset_with_sweeps(monkeypatch):
+    adapter = BCD325P2Adapter()
+
+    calls = {}
+
+    def configure_stub(ser, preset):
+        calls["preset"] = preset
+        adapter.band_scope_width = 5
+        return "OK"
+
+    def stream_stub(ser, c, debug=False):
+        calls["count"] = c
+        yield (10, 144.0, 0)
+
+    monkeypatch.setattr(adapter, "configure_band_scope", configure_stub)
+    monkeypatch.setattr(adapter, "stream_custom_search", stream_stub)
+
+    commands, _ = build_command_table(adapter, None)
+    commands["band scope"](None, adapter, "ham2m 2")
+
+    assert calls["preset"] == "ham2m"
+    assert calls["count"] == adapter.band_scope_width * 2
+
+
 def test_band_scope_respects_preset_range(monkeypatch):
     adapter = BCD325P2Adapter()
     adapter.in_program_mode = True


### PR DESCRIPTION
## Summary
- allow `band scope` to accept a preset name and configure the scanner before sweeping
- document new syntax `band scope <preset> [sweeps] [list|hits]`
- test preset invocation and sweep counts for `band scope`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d077c3eb48324a4152b3c6fdcf61d