### PR TITLE
Relax band scope OK response

### DIFF
--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -347,6 +347,28 @@ def test_band_scope_preset_with_sweeps(monkeypatch):
     assert calls["count"] == adapter.band_scope_width * 2
 
 
+def test_band_scope_accepts_non_exact_ok_response(monkeypatch):
+    adapter = BCD325P2Adapter()
+
+    calls = {"stream": 0}
+
+    def configure_stub(ser, preset):
+        adapter.band_scope_width = 5
+        return "BSP,OK"
+
+    def stream_stub(ser, c, debug=False):
+        calls["stream"] += 1
+        yield (10, 100.0, 0)
+
+    monkeypatch.setattr(adapter, "configure_band_scope", configure_stub)
+    monkeypatch.setattr(adapter, "stream_custom_search", stream_stub)
+
+    commands, _ = build_command_table(adapter, None)
+    commands["band scope"](None, adapter, "air")
+
+    assert calls["stream"] == 1
+
+
 def test_band_scope_respects_preset_range(monkeypatch):
     adapter = BCD325P2Adapter()
     adapter.in_program_mode = True

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -230,7 +230,7 @@ def build_command_table(adapter, ser):
 
             if preset and hasattr(adapter_, "configure_band_scope"):
                 result = adapter_.configure_band_scope(ser_, preset)
-                if result and result != "OK":
+                if result and "OK" not in result.upper():
                     return result
 
             if getattr(adapter_, "in_program_mode", False):


### PR DESCRIPTION
## Summary
- treat any band scope configuration response containing `OK` (case-insensitive) as success
- add regression test for adapters returning `BSP,OK`

## Testing
- `pytest tests/test_band_scope.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688d12d1ef248324befece4ed4945525