### PR TITLE
Add list/hits modes for band scope output

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,14 +182,16 @@ scanner outputs lines of the form `CSC,<RSSI>,<FRQ>,<SQL>` for each hit. The
 controller now processes data in **sweeps**. Each sweep gathers
 `band_scope_width` records (falling back to 1024 if that width is unknown). The
 CLI's `band scope` command takes a preset name followed by an optional sweep
-count; providing a number runs that many sweeps. Before streaming, the total
-record count is calculated as `band_scope_width * sweeps`. After the final record
-the command `CSC,OFF` is issued and the final `CSC,OK` response is read.
-When called through the CLI these readings are printed as a list of hit
-frequencies with their normalized signal strength. After all hits a summary line
-describes the sweep parameters. Only results with RSSI above zero are printed:
+count and mode; providing a number runs that many sweeps. Before streaming, the
+total record count is calculated as `band_scope_width * sweeps`. After the final
+record the command `CSC,OFF` is issued and the final `CSC,OK` response is read.
+In **list** mode (the default) every `(frequency, RSSI)` pair collected during
+the sweeps is printed. In **hits** mode the mean RSSI is computed and only
+frequencies more than 20% above that mean are displayed. After all readings a
+summary line describes the sweep parameters:
 
 ```text
+145.0000, 0.000
 146.5200, 0.450
 147.0400, 0.610
 center=146.000 min=145.000 max=147.000 span=2M step=0.5M mod=FM
@@ -204,7 +206,8 @@ printed contains the frequency in megahertz and the normalized RSSI level:
 
 For example: `162.5500, 0.450`. This format is consistent in both human and
 machine modes and is convenient for logging or further processing. Use the
-optional `list` or `hits` argument to show only channels with activity:
+optional mode argument to control output: `list` displays all values while
+`hits` shows only entries 20% above the mean RSSI level:
 
 ```text
 > band scope <preset> [sweeps] [list|hits]
@@ -262,12 +265,12 @@ Connected to /dev/ttyUSB1 [ID 2]
 [2]  /dev/ttyUSB1
 > use 1
 Using connection 1
-> band scope 20
+> band scope 20 hits
 (hits for scanner 1)
 center=...
 > use 2
 Using connection 2
-> band scope 20
+> band scope 20 hits
 (hits for scanner 2)
 center=...
 ```

--- a/tests/test_band_scope.py
+++ b/tests/test_band_scope.py
@@ -122,7 +122,7 @@ def test_band_scope_auto_width(monkeypatch):
     monkeypatch.setattr(adapter, "stream_custom_search", fake_stream)
 
     commands, _ = build_command_table(adapter, None)
-    output = commands["band scope"](None, adapter, "5")
+    output = commands["band scope"](None, adapter, "5 hits")
     lines = output.splitlines()
     assert len(lines) == 1
     assert lines[0].startswith("center=")
@@ -200,7 +200,7 @@ def test_configure_band_scope_sets_width(monkeypatch):
     monkeypatch.setattr(adapter, "stream_custom_search", fake_stream)
 
     commands, _ = build_command_table(adapter, None)
-    output = commands["band scope"](None, adapter, "5")
+    output = commands["band scope"](None, adapter, "5 hits")
     lines = output.splitlines()
     assert len(lines) == 1
     assert lines[0].startswith("center=")
@@ -277,7 +277,7 @@ def test_band_scope_in_program_mode(monkeypatch):
     assert not called
 
 
-def test_band_scope_list_hits(monkeypatch):
+def test_band_scope_modes(monkeypatch):
     adapter = BCD325P2Adapter()
 
     counts = []
@@ -292,11 +292,27 @@ def test_band_scope_list_hits(monkeypatch):
     monkeypatch.setattr(adapter, "stream_custom_search", stream_stub)
 
     commands, _ = build_command_table(adapter, None)
-    output = commands["band scope"](None, adapter, "list")
-    lines = output.splitlines()
-    assert lines[:2] == ["146.0000, 0.049", "148.0000, 0.029"]
-    assert lines[-1].startswith("center=")
-    assert counts[0] == 1024
+
+    # Default (list) mode
+    output_default = commands["band scope"](None, adapter, "")
+    output_list = commands["band scope"](None, adapter, "list")
+    lines_default = output_default.splitlines()
+    assert lines_default[:4] == [
+        "145.0000, 0.000",
+        "146.0000, 0.049",
+        "147.0000, 0.000",
+        "148.0000, 0.029",
+    ]
+    assert lines_default[-1].startswith("center=")
+    assert output_default == output_list
+
+    # Hits mode filters entries 20% above mean RSSI
+    output_hits = commands["band scope"](None, adapter, "hits")
+    lines_hits = output_hits.splitlines()
+    assert lines_hits[:2] == ["146.0000, 0.049", "148.0000, 0.029"]
+    assert lines_hits[-1].startswith("center=")
+
+    assert counts == [1024, 1024, 1024]
 
 
 def test_band_scope_preset_invocation(monkeypatch):

--- a/tests/test_custom_search.py
+++ b/tests/test_custom_search.py
@@ -30,7 +30,7 @@ def test_band_scope_command_registered(monkeypatch):
 
     assert "band scope" in commands
     assert "band scope" in help_text
-    output = commands["band scope"](None, adapter, "10")
+    output = commands["band scope"](None, adapter, "10 hits")
     lines = output.splitlines()
     assert len(lines) == 1
     assert lines[0].startswith("center=")


### PR DESCRIPTION
## Summary
- replace unused `list_hits` flag with `mode` ("list" or "hits")
- support default full listing and optional hit filtering (>120% mean RSSI)
- document list vs hits behavior in README
- expand band scope tests for new modes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d16ff6fe08324b5bb4f2fe1b23297