### PR TITLE
Add cancellable Close Call search helper

### DIFF
--- a/tests/test_close_call_search.py
+++ b/tests/test_close_call_search.py
@@ -1,0 +1,112 @@
+"""Tests for close_call_search."""
+
+import io
+import os
+import sys
+import time
+import types
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+serial_stub = types.ModuleType("serial")
+serial_stub.Serial = lambda *a, **k: None
+serial_tools_stub = types.ModuleType("serial.tools")
+list_ports_stub = types.ModuleType("serial.tools.list_ports")
+list_ports_stub.comports = lambda *a, **k: []
+serial_tools_stub.list_ports = list_ports_stub
+serial_stub.tools = serial_tools_stub
+sys.modules.setdefault("serial.tools", serial_tools_stub)
+sys.modules.setdefault("serial.tools.list_ports", list_ports_stub)
+sys.modules.setdefault("serial", serial_stub)
+
+from config.close_call_bands import CLOSE_CALL_BANDS  # noqa: E402
+from utilities.scanner.close_call_search import close_call_search  # noqa: E402
+
+
+class DummyAdapter:
+    def __init__(self):
+        self.mask = None
+        self.jumped = None
+
+    def set_close_call(self, ser, params):
+        self.mask = params
+
+    def jump_mode(self, ser, mode):
+        self.jumped = mode
+
+    def read_frequency(self, ser):
+        raise NotImplementedError
+
+    def read_rssi(self, ser):
+        return 0.5
+
+
+def test_search_max_hits(monkeypatch):
+    adapter = DummyAdapter()
+    calls = [130.0, 131.0, 132.0]
+
+    def freq_stub(ser):
+        return calls.pop(0)
+
+    monkeypatch.setattr(adapter, "read_frequency", freq_stub)
+
+    hits, completed = close_call_search(
+        adapter, None, "air", max_hits=2, input_stream=io.StringIO("")
+    )
+
+    assert len(hits) == 2
+    assert completed
+    assert adapter.mask == CLOSE_CALL_BANDS["air"]
+
+
+def test_search_max_time(monkeypatch):
+    adapter = DummyAdapter()
+    calls = [130.0, 131.0, 132.0]
+
+    def freq_stub(ser):
+        return calls.pop(0)
+
+    monkeypatch.setattr(adapter, "read_frequency", freq_stub)
+
+    t = {"i": 0}
+
+    def time_stub():
+        t["i"] += 0.05
+        return t["i"]
+
+    monkeypatch.setattr(time, "time", time_stub)
+
+    hits, completed = close_call_search(
+        adapter, None, "air", max_time=0.25, input_stream=io.StringIO("")
+    )
+
+    assert len(hits) == 2
+    assert completed
+
+
+class DummyInput:
+    def __init__(self, responses):
+        self.responses = list(responses)
+
+    def read(self, n=1):
+        if self.responses:
+            return self.responses.pop(0)
+        return ""
+
+
+def test_search_user_cancel(monkeypatch):
+    adapter = DummyAdapter()
+    calls = [130.0, 131.0, 132.0]
+
+    def freq_stub(ser):
+        return calls.pop(0)
+
+    monkeypatch.setattr(adapter, "read_frequency", freq_stub)
+
+    input_stream = DummyInput(["", "q"])
+    hits, completed = close_call_search(
+        adapter, None, "air", max_hits=5, input_stream=input_stream
+    )
+
+    assert len(hits) == 1
+    assert not completed

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -37,6 +37,11 @@ try:
 except Exception:  # pragma: no cover - optional import for tests
     record_close_calls = None
 
+try:
+    from utilities.scanner.close_call_search import close_call_search
+except Exception:  # pragma: no cover - optional import for tests
+    close_call_search = None
+
 # Only export specific names (instead of using __all__ = ['*'])
 __all__ = [
     "configure_logging",
@@ -61,4 +66,5 @@ __all__ = [
     "wait_for_data",
     "render_rssi_graph",
     "record_close_calls",
+    "close_call_search",
 ]

--- a/utilities/scanner/close_call_search.py
+++ b/utilities/scanner/close_call_search.py
@@ -1,0 +1,105 @@
+"""Utility to perform a Close Call search and return hits."""
+
+from __future__ import annotations
+
+import select
+import sys
+import time
+from typing import IO, List, Optional, Tuple
+
+from config.close_call_bands import CLOSE_CALL_BANDS
+
+
+def _parse_float(value: object) -> Optional[float]:
+    """Return a float from ``value`` if possible."""
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        digits = "".join(ch for ch in str(value) if ch.isdigit() or ch == ".")
+        return float(digits) if digits else None
+    except Exception:
+        return None
+
+
+def _user_requested_exit(stream: IO[str]) -> bool:
+    """Return ``True`` if the user requested cancellation."""
+    try:
+        if hasattr(stream, "fileno"):
+            r, _, _ = select.select([stream], [], [], 0)
+            if r:
+                ch = stream.read(1)
+                return ch in {"q", "Q", "\n", "\r"}
+        else:
+            ch = stream.read(1)
+            return ch in {"q", "Q", "\n", "\r"}
+    except Exception:
+        return False
+    return False
+
+
+def close_call_search(
+    adapter,
+    ser,
+    band,
+    *,
+    max_hits: Optional[int] = None,
+    max_time: Optional[float] = None,
+    input_stream: Optional[IO[str]] = None,
+) -> Tuple[List[Tuple[float, Optional[float], str, Optional[float]]], bool]:
+    """Collect Close Call hits within a band.
+
+    Parameters
+    ----------
+    max_hits : int, optional
+        Stop searching after this many hits have been collected.
+    max_time : float, optional
+        Stop searching after this many seconds have elapsed.
+    input_stream : IO, optional
+        Stream to poll for user cancellation; defaults to ``sys.stdin``.
+
+    Returns
+    -------
+    hits : list of tuples
+        Each tuple contains ``(timestamp, frequency, tone, rssi)``.
+    completed : bool
+        ``True`` if the search completed normally, ``False`` if cancelled.
+    """
+    band_key = str(band).lower()
+    if band_key not in CLOSE_CALL_BANDS:
+        raise KeyError(f"Unknown band: {band}")
+
+    mask = CLOSE_CALL_BANDS[band_key]
+    adapter.set_close_call(ser, mask)
+    adapter.jump_mode(ser, "CC_MODE")
+
+    hits: List[Tuple[float, Optional[float], str, Optional[float]]] = []
+    start_time = time.time()
+    cancelled = False
+    stream = input_stream if input_stream is not None else sys.stdin
+
+    try:
+        while True:
+            if max_hits is not None and len(hits) >= max_hits:
+                break
+            if max_time is not None and time.time() - start_time >= max_time:
+                break
+            if _user_requested_exit(stream):
+                cancelled = True
+                break
+            try:
+                freq_raw = adapter.read_frequency(ser)
+                freq = _parse_float(freq_raw)
+                tone = ""
+                if hasattr(adapter, "read_tone"):
+                    tone = adapter.read_tone(ser)
+                rssi_raw = adapter.read_rssi(ser)
+                rssi = _parse_float(rssi_raw)
+                ts = time.time()
+                hits.append((ts, freq, tone, rssi))
+            except KeyboardInterrupt:
+                cancelled = True
+                break
+    finally:
+        pass
+
+    return hits, not cancelled


### PR DESCRIPTION
## Summary
- add `close_call_search` helper to collect Close Call hits with optional `max_hits`/`max_time` limits
- expose `close_call_search` from `utilities` package
- test `close_call_search` behavior including cancellation, max hits, and max time

## Testing
- `pre-commit run --files utilities/scanner/close_call_search.py utilities/__init__.py tests/test_close_call_search.py` *(fails: CalledProcessError: git fetch origin --tags: 403)*
- `pytest tests/test_close_call_search.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d2f3553c48324be7346e8b288936b