### PR TITLE
Preserve and restore Close Call settings and mode

### DIFF
--- a/tests/test_close_call_search.py
+++ b/tests/test_close_call_search.py
@@ -25,15 +25,24 @@ from utilities.scanner.close_call_search import close_call_search  # noqa: E402
 
 class DummyAdapter:
     def __init__(self):
-        self.mask = None
-        self.jumped = None
+        self.set_calls = []
+        self.jump_calls = []
         self.commands = []
+        self.scanned = False
+
+    def get_close_call(self, ser):
+        return "ORIG"
 
     def set_close_call(self, ser, params):
-        self.mask = params
+        self.set_calls.append(params)
 
     def jump_mode(self, ser, mode):
-        self.jumped = mode
+        self.jump_calls.append(mode)
+        if mode == "":
+            return "SCN_MODE"
+
+    def start_scanning(self, ser):
+        self.scanned = True
 
     def read_frequency(self, ser):
         raise NotImplementedError
@@ -60,7 +69,9 @@ def test_search_max_hits(monkeypatch):
 
     assert len(hits) == 2
     assert completed
-    assert adapter.mask == CLOSE_CALL_BANDS["air"]
+    assert adapter.set_calls == [CLOSE_CALL_BANDS["air"], "ORIG"]
+    assert adapter.jump_calls == ["", "CC_MODE"]
+    assert adapter.scanned
 
 
 def test_search_max_time(monkeypatch):

--- a/utilities/scanner/close_call_search.py
+++ b/utilities/scanner/close_call_search.py
@@ -68,6 +68,13 @@ def close_call_search(
     band_key = str(band).lower()
     if band_key not in CLOSE_CALL_BANDS:
         raise KeyError(f"Unknown band: {band}")
+    # Save current Close Call settings and scanner mode so we can restore them
+    # after the search completes.
+    current_settings = adapter.get_close_call(ser)
+    try:
+        current_mode = adapter.jump_mode(ser, "")
+    except Exception:  # pragma: no cover - best effort only
+        current_mode = None
 
     mask = CLOSE_CALL_BANDS[band_key]
     adapter.set_close_call(ser, mask)
@@ -108,6 +115,24 @@ def close_call_search(
         for freq in locked:
             try:
                 adapter.send_command(ser, f"ULF,{freq}")
+            except Exception:
+                pass
+
+        # Restore original Close Call settings and resume prior mode
+        try:
+            adapter.set_close_call(ser, current_settings)
+        except Exception:  # pragma: no cover - best effort only
+            pass
+        try:
+            if current_mode == "SCN_MODE":
+                adapter.start_scanning(ser)
+            elif current_mode:
+                adapter.jump_mode(ser, current_mode)
+            else:
+                adapter.start_scanning(ser)
+        except Exception:  # pragma: no cover - best effort only
+            try:
+                adapter.start_scanning(ser)
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary
- save current Close Call settings and scanner mode before jumping to Close Call
- restore prior settings and resume scanning after search/log completes
- adjust tests for new Close Call restore behavior

## Testing
- `pytest tests/test_close_call_search.py tests/test_close_call_logger.py`


------
https://chatgpt.com/codex/tasks/task_e_688d3526459c83248b1e1f0be8e8c817