### PR TITLE
Allow close call search cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,10 @@ optional mode argument to control output: `list` displays all values while
 ```
 
 The `cc search` subcommand performs a Close Call search within the chosen
-band and prints any hit frequencies after the search ends. The `cc log`
-variant starts continuous logging of hits until interrupted.
+band and prints any hit frequencies after the search ends. Press **Enter** or
+`q` at any time to terminate the search and restore the scanner's previous
+settings. The `cc log` variant starts continuous logging of hits until
+interrupted.
 
 ### Close Call Logging
 

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -211,7 +211,12 @@ def build_command_table(adapter, ser):
                             close_call_search,
                         )
 
-                        hits, _ = close_call_search(adapter_, ser_, preset)
+                        # Allow the user to terminate the search by pressing
+                        # Enter or ``q``. The adapter's previous settings are
+                        # restored automatically.
+                        hits, _ = close_call_search(
+                            adapter_, ser_, preset, input_stream=sys.stdin
+                        )
                         return "\n".join(
                             f"{freq:.4f}"
                             for _, freq, _, _ in hits
@@ -353,7 +358,8 @@ def build_command_table(adapter, ser):
         COMMANDS["band scope"] = band_scope
         COMMAND_HELP["band scope"] = (
             "Stream band scope data or manage Close Call. Usage: band scope <preset> "
-            "[sweeps] [list|hits] | band scope <preset> cc search|log"
+            "[sweeps] [list|hits] | band scope <preset> cc search|log. "
+            "During 'cc search', press Enter or 'q' to stop."
         )
 
         logging.debug("Registering 'band sweep' command")

--- a/utilities/scanner/close_call_search.py
+++ b/utilities/scanner/close_call_search.py
@@ -24,7 +24,7 @@ def _parse_float(value: object) -> Optional[float]:
 
 
 def _user_requested_exit(stream: IO[str]) -> bool:
-    """Return ``True`` if the user requested cancellation."""
+    """Return ``True`` if the user pressed Enter or ``q`` to cancel."""
     try:
         if hasattr(stream, "fileno"):
             r, _, _ = select.select([stream], [], [], 0)
@@ -50,6 +50,10 @@ def close_call_search(
     lockout: bool = False,
 ) -> Tuple[List[Tuple[float, Optional[float], str, Optional[float]]], bool]:
     """Collect Close Call hits within a band.
+
+    Press ``Enter`` or ``q`` while the search is running to stop early. The
+    scanner's previous Close Call and mode settings are restored before
+    returning.
 
     Parameters
     ----------
@@ -113,6 +117,7 @@ def close_call_search(
             elapsed = time.time() - start_time
             sys.stdout.write(
                 f"\r{next(spinner)} Hits: {len(hits)} Elapsed: {elapsed:0.1f}s"
+                " (press Enter or 'q' to stop)"
             )
             sys.stdout.flush()
             try:


### PR DESCRIPTION
## Summary
- Allow users to abort Close Call searches with Enter or `q` while restoring original settings
- Pass stdin to `close_call_search` from the `band scope` command and document the new exit option
- Document Close Call search termination in the README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e4a3611688324800e3a720bb4fa7b