### PR TITLE
Handle Windows keyboard cancellation in close call search

### DIFF
--- a/utilities/scanner/close_call_search.py
+++ b/utilities/scanner/close_call_search.py
@@ -26,14 +26,21 @@ def _parse_float(value: object) -> Optional[float]:
 def _user_requested_exit(stream: IO[str]) -> bool:
     """Return ``True`` if the user pressed Enter or ``q`` to cancel."""
     try:
-        if hasattr(stream, "fileno"):
-            r, _, _ = select.select([stream], [], [], 0)
-            if r:
-                ch = stream.read(1)
+        if sys.platform == "win32":
+            import msvcrt  # type: ignore
+
+            if msvcrt.kbhit():
+                ch = msvcrt.getwch()
                 return ch in {"q", "Q", "\n", "\r"}
         else:
-            ch = stream.read(1)
-            return ch in {"q", "Q", "\n", "\r"}
+            if hasattr(stream, "fileno"):
+                r, _, _ = select.select([stream], [], [], 0)
+                if r:
+                    ch = stream.read(1)
+                    return ch in {"q", "Q", "\n", "\r"}
+            else:
+                ch = stream.read(1)
+                return ch in {"q", "Q", "\n", "\r"}
     except Exception:
         return False
     return False


### PR DESCRIPTION
## Summary
- Detect Windows keyboard input using `msvcrt.kbhit()`/`getwch()` in `close_call_search` cancellation helper
- Fall back to existing `select` logic on other platforms
- Test Windows-specific cancellation behavior via `msvcrt` monkeypatching for `q` and Enter

## Testing
- `pytest tests/test_close_call_search.py::test_user_cancel_windows -q`
- `pytest tests/test_close_call_search.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688e4cc544fc832485c8fd7806e08e62