### PR TITLE
Add band scope logger

### DIFF
--- a/tests/test_band_scope_logger.py
+++ b/tests/test_band_scope_logger.py
@@ -1,0 +1,87 @@
+"""Tests for band_scope_logger.record_band_scope."""
+
+import json
+import os
+import sqlite3
+import sys
+import types
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+serial_stub = types.ModuleType("serial")
+serial_stub.Serial = lambda *a, **k: None
+serial_tools_stub = types.ModuleType("serial.tools")
+list_ports_stub = types.ModuleType("serial.tools.list_ports")
+list_ports_stub.comports = lambda *a, **k: []
+serial_tools_stub.list_ports = list_ports_stub
+serial_stub.tools = serial_tools_stub
+sys.modules.setdefault("serial.tools", serial_tools_stub)
+sys.modules.setdefault("serial.tools.list_ports", list_ports_stub)
+sys.modules.setdefault("serial", serial_stub)
+
+from utilities.scanner.band_scope_logger import record_band_scope  # noqa: E402
+
+
+class DummyAdapter:
+    """Simple adapter stub used for testing."""
+
+    def __init__(self):
+        """Store call history and band scope width."""
+        self.configure_calls = []
+        self.stream_calls = []
+        self.band_scope_width = 5
+
+    def configure_band_scope(self, ser, preset):
+        """Record invocation of the configuration routine."""
+        self.configure_calls.append(preset)
+        return "OK"
+
+    def stream_custom_search(self, ser, count, debug=False):
+        """Yield ``count`` sequential test records."""
+        self.stream_calls.append(count)
+        for i in range(count):
+            yield (i, 100.0 + i, 0)
+
+
+def test_record_band_scope_csv(tmp_path):
+    """CSV output contains all expected lines."""
+    adapter = DummyAdapter()
+    base = tmp_path / "scope"
+    record_band_scope(
+        adapter, None, "air", sweeps=2, format="csv", path=str(base)
+    )
+    assert adapter.configure_calls == ["air"]
+    assert adapter.stream_calls == [10]
+    csv_file = base.with_suffix(".csv")
+    lines = csv_file.read_text().strip().splitlines()
+    assert lines[0] == "rssi,freq"
+    assert len(lines) == 11
+    assert lines[1] == "0,100.0"
+
+
+def test_record_band_scope_json(tmp_path):
+    """JSON output serializes records as objects."""
+    adapter = DummyAdapter()
+    base = tmp_path / "scope"
+    record_band_scope(
+        adapter, None, "air", sweeps=1, format="json", path=str(base)
+    )
+    json_file = base.with_suffix(".json")
+    data = json.loads(json_file.read_text())
+    assert len(data) == 5
+    assert data[0] == {"rssi": 0, "freq": 100.0}
+
+
+def test_record_band_scope_sqlite(tmp_path):
+    """SQLite output persists rows to the database."""  # noqa: D403
+    adapter = DummyAdapter()
+    base = tmp_path / "scope"
+    record_band_scope(
+        adapter, None, "air", sweeps=1, format="sqlite", path=str(base)
+    )
+    db_file = base.with_suffix(".db")
+    conn = sqlite3.connect(db_file)
+    rows = conn.execute("SELECT rssi, frequency FROM band_scope").fetchall()
+    conn.close()
+    assert len(rows) == 5
+    assert rows[0] == (0, 100.0)

--- a/utilities/scanner/band_scope_logger.py
+++ b/utilities/scanner/band_scope_logger.py
@@ -1,0 +1,96 @@
+"""Utilities for logging band scope sweeps."""
+
+from __future__ import annotations
+
+import csv
+import json
+import sqlite3
+from typing import Sequence, Tuple
+
+Record = Tuple[float, float]
+
+
+def _write_csv(filename: str, records: Sequence[Record]) -> None:
+    """Write ``records`` to ``filename`` in CSV format."""
+    with open(filename, "w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rssi", "freq"])
+        for rssi, freq in records:
+            writer.writerow([rssi, freq])
+
+
+def _write_json(filename: str, records: Sequence[Record]) -> None:
+    """Write ``records`` to ``filename`` in JSON format."""
+    data = [{"rssi": rssi, "freq": freq} for rssi, freq in records]
+    with open(filename, "w", encoding="utf-8") as fh:
+        json.dump(data, fh)
+
+
+def _write_db(filename: str, records: Sequence[Record]) -> None:
+    """Persist ``records`` to a SQLite database at ``filename``."""
+    conn = sqlite3.connect(filename)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS band_scope (rssi REAL, frequency REAL)"
+    )
+    cur.executemany("INSERT INTO band_scope VALUES (?, ?)", records)
+    conn.commit()
+    conn.close()
+
+
+_FORMATTERS = {
+    "csv": (_write_csv, ".csv"),
+    "json": (_write_json, ".json"),
+    "sqlite": (_write_db, ".db"),
+    "db": (_write_db, ".db"),
+}
+
+
+def record_band_scope(
+    adapter,
+    ser,
+    preset: str,
+    sweeps: int = 1,
+    format: str = "csv",
+    path: str = "band_scope",
+) -> None:
+    """Record band scope sweeps using ``adapter.stream_custom_search``.
+
+    Parameters
+    ----------
+    adapter : object
+        Scanner adapter implementing ``configure_band_scope`` and
+        ``stream_custom_search``.
+    ser : serial.Serial
+        Serial connection to the scanner.
+    preset : str
+        Band scope preset to configure before streaming.
+    sweeps : int, optional
+        Number of sweeps to capture. Default is ``1``.
+    format : str, optional
+        Output format: ``"csv"``, ``"json"``, or ``"sqlite"``.
+        Default ``"csv"``.
+    path : str, optional
+        Base filename for output. Extensions are added automatically.
+    """
+    if preset and hasattr(adapter, "configure_band_scope"):
+        resp = adapter.configure_band_scope(ser, preset)
+        if resp and "OK" not in str(resp).upper():
+            return
+
+    width = getattr(adapter, "band_scope_width", None) or 1024
+    count = width * sweeps
+
+    records = [
+        (rssi, freq)
+        for rssi, freq, _ in adapter.stream_custom_search(ser, count)
+    ]
+    if not records:
+        return
+
+    fmt_key = format.lower()
+    if fmt_key not in _FORMATTERS:
+        raise ValueError(f"Unknown format: {format}")
+    writer, suffix = _FORMATTERS[fmt_key]
+    filename = f"{path}{suffix}"
+    writer(filename, records)


### PR DESCRIPTION
## Summary
- add `record_band_scope` utility for capturing band scope sweeps
- support CSV, JSON, and SQLite outputs via modular writer helpers
- test band scope logging across output formats

## Testing
- `flake8 utilities/scanner/band_scope_logger.py tests/test_band_scope_logger.py`
- `python -m black utilities/scanner/band_scope_logger.py tests/test_band_scope_logger.py`
- `pytest tests/test_band_scope_logger.py`
- `pre-commit run --files utilities/scanner/band_scope_logger.py tests/test_band_scope_logger.py` *(fails: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688e6bcc48a08324809bbaa798c601d8