### PR TITLE
Convert BC125AT band scope RSSI to integers

### DIFF
--- a/adapters/uniden/bc125at_adapter.py
+++ b/adapters/uniden/bc125at_adapter.py
@@ -320,6 +320,8 @@ class BC125ATAdapter(UnidenScannerAdapter):
                 try:
                     if isinstance(rssi_val, str) and "RSSI" in rssi_val:
                         rssi_val = float(rssi_val.split("RSSI")[-1].split()[0])
+                    if rssi_val is not None:
+                        rssi_val = int(float(rssi_val) * 1023)
                 except Exception:
                     rssi_val = None
                 results.append((round(freq, 6), rssi_val))

--- a/tests/test_bc125at_band_scope.py
+++ b/tests/test_bc125at_band_scope.py
@@ -25,9 +25,10 @@ def test_bc125at_sweep_parses_units(monkeypatch):
     monkeypatch.setattr(
         adapter, "enter_quick_frequency_hold", lambda ser, f: None
     )
-    monkeypatch.setattr(adapter, "read_rssi", lambda ser: 0)
+    monkeypatch.setattr(adapter, "read_rssi", lambda ser: 1.0)
     result = adapter.sweep_band_scope(None, "144M", "2M", "500k", "500k")
     assert result[0][0] == 143.0
+    assert result[0][1] == 1023
 
 
 def test_bc125at_band_scope_auto_width(monkeypatch):


### PR DESCRIPTION
## Summary
- convert RSSI readings to 0–1023 integers when sweeping the band scope
- expect integer RSSI values in BC125AT band scope tests

## Testing
- `pytest tests/test_bc125at_band_scope.py`


------
https://chatgpt.com/codex/tasks/task_e_688e735f08ec83248b7734ab95960198