### PR TITLE
Unify band scope field name

### DIFF
--- a/tests/test_band_scope_logger.py
+++ b/tests/test_band_scope_logger.py
@@ -1,0 +1,69 @@
+"""Tests for :mod:`utilities.scanner.band_scope_logger`."""
+
+import os
+import sys
+import csv
+import json
+import sqlite3
+import types
+
+# Ensure project root is on path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide minimal serial stub so scanner utilities import without pyserial
+serial_stub = types.ModuleType("serial")
+serial_stub.Serial = lambda *a, **k: None
+serial_tools_stub = types.ModuleType("serial.tools")
+list_ports_stub = types.ModuleType("serial.tools.list_ports")
+serial_tools_stub.list_ports = list_ports_stub
+serial_stub.tools = serial_tools_stub
+sys.modules.setdefault("serial", serial_stub)
+sys.modules.setdefault("serial.tools", serial_tools_stub)
+sys.modules.setdefault("serial.tools.list_ports", list_ports_stub)
+
+from utilities.scanner.band_scope_logger import (  # noqa: E402
+    FREQ_FIELD,
+    record_band_scope,
+)
+
+
+RECORDS = [(10.0, 0.1), (20.0, 0.2)]
+SUMMARY = "test summary"
+
+
+def test_csv_field_name(tmp_path):
+    """CSV output uses the expected frequency field name."""
+    out = tmp_path / "out.csv"
+    record_band_scope(RECORDS, SUMMARY, "csv", out)
+    with open(out) as fh:
+        reader = csv.DictReader(fh)
+        assert reader.fieldnames == [FREQ_FIELD, "rssi"]
+        rows = [row for row in reader if row["rssi"]]
+    assert len(rows) == len(RECORDS)
+    assert float(rows[0][FREQ_FIELD]) == RECORDS[0][0]
+
+
+def test_json_field_name(tmp_path):
+    """JSON output uses the expected frequency field name."""
+    out = tmp_path / "out.json"
+    record_band_scope(RECORDS, SUMMARY, "json", out)
+    with open(out) as fh:
+        data = json.load(fh)
+    assert FREQ_FIELD in data["records"][0]
+    assert data["records"][0][FREQ_FIELD] == RECORDS[0][0]
+
+
+def test_db_field_name(tmp_path):
+    """Verify SQLite output uses the expected frequency field name."""
+    out = tmp_path / "out.db"
+    record_band_scope(RECORDS, SUMMARY, "db", out)
+    conn = sqlite3.connect(out)
+    cur = conn.cursor()
+    cur.execute("PRAGMA table_info(band_scope)")
+    cols = [info[1] for info in cur.fetchall()]
+    assert FREQ_FIELD in cols
+    cur.execute(f"SELECT {FREQ_FIELD}, rssi FROM band_scope")
+    rows = cur.fetchall()
+    conn.close()
+    assert len(rows) == len(RECORDS)
+    assert rows[0][0] == RECORDS[0][0]

--- a/utilities/scanner/band_scope_logger.py
+++ b/utilities/scanner/band_scope_logger.py
@@ -10,12 +10,55 @@ from typing import Iterable, Tuple
 
 logger = logging.getLogger(__name__)
 
+#: Column/key name used to store the frequency value across all formats.
+FREQ_FIELD = "frequency"
+
+
+def _write_csv(
+    records: Iterable[Tuple[float, float]], summary: str, path: str
+) -> str:
+    """Write band scope data to ``path`` in CSV format."""
+    with open(path, "w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow([FREQ_FIELD, "rssi"])
+        writer.writerows(records)
+        writer.writerow([])
+        writer.writerow([summary])
+    return path
+
+
+def _write_json(
+    records: Iterable[Tuple[float, float]], summary: str, path: str
+) -> str:
+    """Write band scope data to ``path`` in JSON format."""
+    data = {
+        "records": [{FREQ_FIELD: freq, "rssi": rssi} for freq, rssi in records],
+        "summary": summary,
+    }
+    with open(path, "w") as fh:
+        json.dump(data, fh)
+    return path
+
+
+def _write_db(
+    records: Iterable[Tuple[float, float]], summary: str, path: str
+) -> str:
+    """Write band scope data to ``path`` in SQLite format."""
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute(
+        f"CREATE TABLE IF NOT EXISTS band_scope ({FREQ_FIELD} REAL, rssi REAL)"
+    )
+    cur.executemany("INSERT INTO band_scope VALUES (?, ?)", records)
+    cur.execute("CREATE TABLE IF NOT EXISTS metadata (summary TEXT)")
+    cur.execute("INSERT INTO metadata VALUES (?)", (summary,))
+    conn.commit()
+    conn.close()
+    return path
+
 
 def record_band_scope(
-    records: Iterable[Tuple[float, float]],
-    summary: str,
-    fmt: str,
-    path: str,
+    records: Iterable[Tuple[float, float]], summary: str, fmt: str, path: str
 ):
     """Record band scope data in various formats.
 
@@ -31,46 +74,18 @@ def record_band_scope(
     path:
         Destination file path.
     """
-
     fmt = fmt.lower()
     if fmt == "csv":
-        with open(path, "w", newline="") as fh:
-            writer = csv.writer(fh)
-            writer.writerow(["frequency", "rssi"])
-            writer.writerows(records)
-            writer.writerow([])
-            writer.writerow([summary])
+        result = _write_csv(records, summary, path)
     elif fmt == "json":
-        data = {
-            "records": [
-                {"frequency": freq, "rssi": rssi} for freq, rssi in records
-            ],
-            "summary": summary,
-        }
-        with open(path, "w") as fh:
-            json.dump(data, fh)
+        result = _write_json(records, summary, path)
     elif fmt == "db":
-        conn = sqlite3.connect(path)
-        cur = conn.cursor()
-        cur.execute(
-            "CREATE TABLE IF NOT EXISTS band_scope (frequency REAL, rssi REAL)"
-        )
-        cur.executemany(
-            "INSERT INTO band_scope VALUES (?, ?)",
-            records,
-        )
-        cur.execute(
-            "CREATE TABLE IF NOT EXISTS metadata (summary TEXT)"
-        )
-        cur.execute("INSERT INTO metadata VALUES (?)", (summary,))
-        conn.commit()
-        conn.close()
+        result = _write_db(records, summary, path)
     else:  # pragma: no cover - defensive programming
         raise ValueError(f"Unsupported format: {fmt}")
 
     logger.info("Band scope data recorded to %s", path)
-    return path
+    return result
 
 
-__all__ = ["record_band_scope"]
-
+__all__ = ["record_band_scope", "FREQ_FIELD"]


### PR DESCRIPTION
## Summary
- add helper functions to band scope logger that share a single frequency field name across CSV, JSON, and SQLite outputs
- exercise the logger helpers with new tests

## Testing
- `python -m black tests/test_band_scope_logger.py utilities/scanner/band_scope_logger.py`
- `python -m flake8 utilities/scanner/band_scope_logger.py tests/test_band_scope_logger.py`
- `pytest tests/test_band_scope_logger.py tests/test_band_scope_logging.py tests/test_band_scope.py -q`
- `pre-commit run --files utilities/scanner/band_scope_logger.py tests/test_band_scope_logger.py` *(fails: unable to access https://github.com/pre-commit/pre-commit-hooks/)*

------
https://chatgpt.com/codex/tasks/task_e_688e8662602483249ff560fd451a7c1b