### PR TITLE
Centralize clear_serial_buffer utility

### DIFF
--- a/utilities/core/__init__.py
+++ b/utilities/core/__init__.py
@@ -33,19 +33,18 @@ if not os.path.exists(core_dir):
 
 # Function Imports
 # ---------------
-# Import core scanner functionality from shared utilities
+# Import core scanner functionality
 # These functions provide the primary interface for scanner communications
 try:
     # Import essential scanner functions for re-export
-    # - clear_serial_buffer: Clears any pending data in the serial connection
-    # - ScannerCommand: Sends formatted commands to the scanner hardware
-    from utilities.core.shared_utils import clear_serial_buffer, ScannerCommand
+    from utilities.core.serial_utils import clear_serial_buffer
+    from utilities.core.shared_utils import ScannerCommand
 except ImportError:
     # This exception handling is for development/refactoring scenarios
     # where the file structure may be in transition
     import sys
 
-    print("Warning: Could not import from utilities.core.shared_utils")
+    print("Warning: Could not import required core utilities")
     print("If you've already moved files, update this import path")
     print(f"Python path: {sys.path}")
     print("Affected functionality: clear_serial_buffer, ScannerCommand")

--- a/utilities/core/scanner_utils.py
+++ b/utilities/core/scanner_utils.py
@@ -1,12 +1,12 @@
 """Compatibility wrappers for scanner utilities."""
 
-from utilities.scanner.backend import (
+from utilities.core.serial_utils import (
     clear_serial_buffer,
     wait_for_data,
     read_response,
     send_command,
-    find_all_scanner_ports,
 )
+from utilities.scanner.backend import find_all_scanner_ports
 
 __all__ = [
     "clear_serial_buffer",

--- a/utilities/core/shared_utils.py
+++ b/utilities/core/shared_utils.py
@@ -1,14 +1,11 @@
-"""
-Shared utilities for scanner communication and control.
+"""Shared utilities for scanner communication and control.
 
 This module provides common functionality used across different scanner adapter
 implementations, including command building and serial communication helpers.
 """
 
-import logging
 import os
 import sys
-import time
 
 
 def ensure_root_in_path():
@@ -117,71 +114,6 @@ class ScannerCommand:
         return self.parser(response) if self.parser else response
 
 
-def clear_serial_buffer(ser, delay=0.0):
-    """Clear accumulated data in the serial buffer before sending commands.
-
-    Parameters
-    ----------
-    ser : serial.Serial
-        Open serial connection to the scanner.
-    delay : float, optional
-        Time to wait before flushing the buffer. Defaults to ``0`` seconds.
-    """
-    try:
-        if delay:
-            time.sleep(delay)
-        while ser.in_waiting:
-            ser.read(ser.in_waiting)
-        logging.debug("Serial buffer cleared.")
-    except Exception as e:
-        logging.error(f"Error clearing serial buffer: {e}")
-
-
-def send_command(ser, cmd, delay=0.0):
-    """Clear the buffer and send a command (with CR termination) to the device.
-
-    Parameters
-    ----------
-    ser : serial.Serial
-        Open serial connection object.
-    cmd : str
-        Command string to send.
-    delay : float, optional
-        Delay passed to :func:`clear_serial_buffer`. Defaults to ``0`` seconds.
-
-    Returns
-    -------
-    str
-        Response from the device as a string.
-    """
-    clear_serial_buffer(ser, delay)
-    full_cmd = cmd.strip() + "\r"
-    try:
-        ser.write(full_cmd.encode("utf-8"))
-        logging.info(f"Sent command: {cmd}")
-    except Exception as e:
-        logging.error(f"Error sending command {cmd}: {e}")
-        return ""
-    return read_response(ser)
-
-
-def read_response(ser, timeout=1.0):
-    """
-    Read a response from the serial port with a timeout.
-
-    Args:
-        ser: An open serial connection object
-        timeout: Maximum time to wait for a response
-
-    Returns:
-        str: The response from the device as a string
-    """
-    ser.timeout = timeout
-    response = ser.read_until(b"\r").decode("utf-8").strip()
-    logging.debug(f"Received response: {response}")
-    return response
-
-
 def diagnose_connection_issues():
     """
     Diagnose common connection issues with the scanner.
@@ -206,3 +138,4 @@ def diagnose_connection_issues():
     print("  2. Check that the correct port is selected.")
     print("  3. Ensure no other application is using the port.")
     print("  4. Try reconnecting the scanner or using a different USB port.")
+

--- a/utilities/scanner/backend.py
+++ b/utilities/scanner/backend.py
@@ -6,25 +6,7 @@ import time
 import serial
 from serial.tools import list_ports
 
-
-def clear_serial_buffer(ser, delay=0.0):
-    """Clear accumulated data in the serial buffer.
-
-    Parameters
-    ----------
-    ser : serial.Serial
-        Open serial connection to the scanner.
-    delay : float, optional
-        Time to wait before flushing the buffer. Defaults to ``0`` seconds.
-    """
-    try:
-        if delay:
-            time.sleep(delay)
-        while ser.in_waiting:
-            ser.read(ser.in_waiting)
-        logging.debug("Serial buffer cleared.")
-    except Exception as e:
-        logging.error(f"Error clearing serial buffer: {e}")
+from utilities.core.serial_utils import clear_serial_buffer
 
 
 def wait_for_data(ser, max_wait=0.3):

--- a/utilities/serial_utils.py
+++ b/utilities/serial_utils.py
@@ -1,88 +1,16 @@
-"""
-This module provides utility functions for serial communication.
+"""Compatibility layer for serial utility functions."""
 
-Including clearing buffers, sending commands, and reading responses.
-"""
+from utilities.core.serial_utils import (
+    clear_serial_buffer,
+    read_response,
+    send_command,
+    wait_for_data,
+)
 
-import logging
-import time
+__all__ = [
+    "clear_serial_buffer",
+    "read_response",
+    "send_command",
+    "wait_for_data",
+]
 
-
-def clear_serial_buffer(ser, delay=0.0):
-    """Clear accumulated data in the serial buffer before sending commands.
-
-    Parameters
-    ----------
-    ser : serial.Serial
-        Open serial connection object.
-    delay : float, optional
-        Time to wait before flushing the buffer. Defaults to ``0`` seconds.
-    """
-    try:
-        if delay:
-            time.sleep(delay)
-        if hasattr(ser, "reset_input_buffer"):
-            ser.reset_input_buffer()
-        else:
-            while ser.in_waiting:
-                ser.read(ser.in_waiting)
-        logging.debug("Serial buffer cleared.")
-    except Exception as e:
-        logging.error(f"Error clearing serial buffer: {e}")
-
-
-def read_response(ser, timeout=1.0):
-    r"""Read a response from the serial port with a timeout."""
-    original_timeout = ser.timeout
-    try:
-        ser.timeout = timeout
-        response = ser.read_until(b"\r").decode("utf-8").strip()
-        logging.debug(f"Received response: {response}")
-        return response
-    except Exception as e:
-        logging.error(f"Error reading response: {e}")
-        return ""
-    finally:
-        ser.timeout = original_timeout
-
-
-def send_command(ser, cmd, delay=0.0):
-    """Clear the buffer and send a command (with CR termination) to the scanner.
-
-    Parameters
-    ----------
-    ser : serial.Serial
-        Open serial connection object.
-    cmd : str
-        Command string to send.
-    delay : float, optional
-        Delay passed to :func:`clear_serial_buffer`. Defaults to ``0`` seconds.
-
-    Returns
-    -------
-    str
-        Response from the scanner.
-    """
-    clear_serial_buffer(ser, delay)
-    full_cmd = cmd.strip() + "\r"
-    try:
-        ser.write(full_cmd.encode("utf-8"))
-        logging.info(f"Sent command: {cmd}")
-    except Exception as e:
-        logging.error(f"Error sending command {cmd}: {e}")
-        return ""
-    return read_response(ser)
-
-
-def wait_for_data(ser, max_wait=0.3):
-    """
-    Wait up to max_wait seconds for incoming data on the serial port.
-
-    Returns True if data is available, otherwise False.
-    """
-    start = time.time()
-    while time.time() - start < max_wait:
-        if ser.in_waiting:
-            return True
-        time.sleep(0.01)
-    return False

--- a/utilities/shared_utils.py
+++ b/utilities/shared_utils.py
@@ -1,11 +1,4 @@
-"""
-This module provides utility functions and classes for scanner control.
-
-It includes serial buffer management and command handling.
-"""
-
-import logging
-import time
+"""Utility classes for scanner control."""
 
 from utilities.errors import CommandError
 
@@ -108,23 +101,3 @@ class ScannerCommand:
                 f"{self.name}: Command returned an error: {response}"
             )
         return self.parser(response) if self.parser else response
-
-
-def clear_serial_buffer(ser, delay=0.0):
-    """Clear accumulated data in the serial buffer before sending commands.
-
-    Parameters
-    ----------
-    ser : serial.Serial
-        Serial connection to clear.
-    delay : float, optional
-        Time to wait before flushing the buffer. Defaults to ``0`` seconds.
-    """
-    try:
-        if delay:
-            time.sleep(delay)
-        while ser.in_waiting:
-            ser.read(ser.in_waiting)
-        logging.debug("Serial buffer cleared.")
-    except Exception as e:
-        logging.error(f"Error clearing serial buffer: {e}")


### PR DESCRIPTION
## Summary
- Consolidate robust `clear_serial_buffer` helper in `utilities/core/serial_utils.py` and expose via compatibility layer.
- Remove duplicate buffer-clearing implementations from legacy utilities and backend.
- Update module imports to use the single shared function.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e9fae9d4c8324bc2eb899f4173633