### PR TITLE
Restore serial timeouts after reads

### DIFF
--- a/tests/test_shared_utils.py
+++ b/tests/test_shared_utils.py
@@ -1,0 +1,16 @@
+"""Tests for shared utilities functions."""
+
+from unittest.mock import MagicMock
+
+from utilities.core.shared_utils import read_response
+
+
+def test_read_response_restores_timeout():
+    """Ensure read_response restores the original timeout."""
+
+    ser = MagicMock()
+    ser.timeout = 5
+    ser.read_until.return_value = b"RES\r"
+
+    read_response(ser, timeout=0.1)
+    assert ser.timeout == 5

--- a/utilities/core/serial_utils.py
+++ b/utilities/core/serial_utils.py
@@ -45,7 +45,7 @@ def read_response(ser, timeout=1.0):
     The serial timeout is temporarily overridden and restored after the
     read completes to avoid side effects on the caller's configuration.
     """
-    original_timeout = getattr(ser, "timeout", None)
+    original_timeout = ser.timeout
     try:
         ser.timeout = timeout
         response = ser.read_until(b"\r").decode("utf-8").strip()
@@ -55,8 +55,7 @@ def read_response(ser, timeout=1.0):
         logging.error(f"Error reading response: {e}")
         return ""
     finally:
-        if original_timeout is not None:
-            ser.timeout = original_timeout
+        ser.timeout = original_timeout
 
 
 def send_command(ser, cmd, delay=0.0):

--- a/utilities/core/shared_utils.py
+++ b/utilities/core/shared_utils.py
@@ -6,6 +6,7 @@ Serial communication helpers can be found in
 ``utilities.core.serial_utils``.
 """
 
+import logging
 import os
 import sys
 
@@ -44,5 +45,26 @@ def diagnose_connection_issues():
     print("  4. Try reconnecting the scanner or using a different USB port.")
 
 
-__all__ = ["ScannerCommand", "ensure_root_in_path", "diagnose_connection_issues"]
+def read_response(ser, timeout=1.0):
+    """Read a response from the serial port with a temporary timeout."""
+
+    original_timeout = ser.timeout
+    try:
+        ser.timeout = timeout
+        response = ser.read_until(b"\r").decode("utf-8").strip()
+        logging.debug(f"Shared utils received response: {response}")
+        return response
+    except Exception as e:  # pragma: no cover - error path
+        logging.error(f"Error reading response: {e}")
+        return ""
+    finally:
+        ser.timeout = original_timeout
+
+
+__all__ = [
+    "ScannerCommand",
+    "ensure_root_in_path",
+    "diagnose_connection_issues",
+    "read_response",
+]
 


### PR DESCRIPTION
## Summary
- ensure serial read utilities save original timeout and restore it after reads
- add shared utility wrapper for serial reads with timeout restoration
- test timeout restoration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688eacfb6b948324a42c2e0334284598