### PR TITLE
refactor: unify Uniden send_command

### DIFF
--- a/adapters/uniden/bc125at_adapter.py
+++ b/adapters/uniden/bc125at_adapter.py
@@ -42,13 +42,7 @@ from adapters.uniden.bc125at.user_control import (
     stop_scanning,
 )
 
-# Import common functions
-from adapters.uniden.common.core import (
-    ensure_bytes,
-    ensure_str,
-    feedback,
-    send_command,
-)
+# Import common programming helpers
 from adapters.uniden.common.programming import (
     enter_programming_mode,
     exit_programming_mode,
@@ -100,14 +94,8 @@ class BC125ATAdapter(UnidenScannerAdapter):
         logger.debug(f"Machine mode ID: {self.machine_mode_id}")
 
     # Import methods from modules
-    # Core methods
-    ensure_bytes = ensure_bytes
-    ensure_str = ensure_str
-    send_command = send_command
-
-    def feedback(self, success, message):
-        """Format feedback based on machine_mode setting."""
-        return feedback(self.machine_mode, success, message)
+    # Core methods inherited from UnidenScannerAdapter include
+    # ensure_bytes, ensure_str, send_command, and feedback
 
     # Override programming mode methods to add logging
     def enter_programming_mode(self, ser):

--- a/adapters/uniden/bcd325p2_adapter.py
+++ b/adapters/uniden/bcd325p2_adapter.py
@@ -46,13 +46,7 @@ from adapters.uniden.bcd325p2.user_control import (
     stop_scanning,
 )
 
-# Import common functions
-from adapters.uniden.common.core import (
-    ensure_bytes,
-    ensure_str,
-    feedback,
-    send_command,
-)
+# Import common programming helpers
 from adapters.uniden.common.programming import (
     enter_programming_mode,
     exit_programming_mode,
@@ -102,14 +96,8 @@ class BCD325P2Adapter(UnidenScannerAdapter):
         self.signal_bandwidth = None
 
     # Import methods from modules
-    # Core methods
-    ensure_bytes = ensure_bytes
-    ensure_str = ensure_str
-    send_command = send_command
-
-    def feedback(self, success, message):
-        """Format feedback based on machine_mode setting."""
-        return feedback(self.machine_mode, success, message)
+    # Core methods inherited from UnidenScannerAdapter include
+    # ensure_bytes, ensure_str, send_command, and feedback
 
     # Override programming mode methods to add logging
     def enter_programming_mode(self, ser):
@@ -155,7 +143,7 @@ class BCD325P2Adapter(UnidenScannerAdapter):
         """Return the normalized RSSI using the ``PWR`` command."""
         try:
             response = self.send_command(ser, "PWR")
-            response_str = ensure_str(response)
+            response_str = self.ensure_str(response)
             parts = response_str.split(",")
             if len(parts) >= 2:
                 return int(parts[1]) / 1023.0
@@ -283,7 +271,7 @@ class BCD325P2Adapter(UnidenScannerAdapter):
                     cmd = f"BSP,{freq},{step},{span},{max_hold}"
 
                 response = self.send_command(ser, cmd)
-                response_str = ensure_str(response)
+                response_str = self.ensure_str(response)
 
                 csp_obj = self.commands.get("CSP")
                 if csp_obj:
@@ -332,7 +320,7 @@ class BCD325P2Adapter(UnidenScannerAdapter):
                         f"{AGC_DIGITAL},{P25WAITING}"
                     )
                 csp_resp = self.send_command(ser, csp_cmd)
-                csp_resp_str = ensure_str(csp_resp)
+                csp_resp_str = self.ensure_str(csp_resp)
                 if "OK" not in csp_resp_str:
                     return self.feedback(False, f"CSP error: {csp_resp_str}")
 
@@ -342,7 +330,7 @@ class BCD325P2Adapter(UnidenScannerAdapter):
                 else:
                     csg_cmd = f"CSG,{CSG_ENABLE_RANGE_1}"
                 csg_resp = self.send_command(ser, csg_cmd)
-                csg_resp_str = ensure_str(csg_resp)
+                csg_resp_str = self.ensure_str(csg_resp)
                 if "OK" not in csg_resp_str:
                     return self.feedback(False, f"CSG error: {csg_resp_str}")
 

--- a/adapters/uniden/common/core.py
+++ b/adapters/uniden/common/core.py
@@ -190,36 +190,3 @@ def format_response(response, pretty=False):
         return f"RESPONSE: {response_str}"
 
 
-def send_command(self, ser, cmd):
-    """Send a command to the scanner and get the response."""
-    try:
-        # Import the utility function instead of calling it directly
-        from utilities.core.serial_utils import send_command as utils_send_command
-
-        # Ensure command is a string before passing to underlying function
-        if isinstance(cmd, bytes):
-            cmd_str = cmd.decode("ascii", errors="replace")
-        else:
-            cmd_str = str(cmd)
-
-        # Use the utility function to send the command
-        response = utils_send_command(ser, cmd_str)
-
-        # Log the command and response
-        logging.debug(
-            f"Command: {cmd_str}, Response type: {type(response)}, "
-            f"Value: {response!r}"
-        )
-
-        # Update programming mode flag when manually issuing PRG/EPG
-        clean_cmd = cmd_str.strip().upper()
-        if clean_cmd in {"PRG", "EPG"} and hasattr(self, "in_program_mode"):
-            resp_str = ensure_str(response)
-            if "OK" in resp_str:
-                self.in_program_mode = clean_cmd == "PRG"
-
-        # Make sure we return bytes for consistency
-        return ensure_bytes(response)
-    except Exception as e:
-        logger.error(f"Error in send_command: {e}")
-        return b""

--- a/tests/test_program_flag.py
+++ b/tests/test_program_flag.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import types
+import pytest
 
 # Ensure project modules can be imported
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -20,11 +21,13 @@ sys.modules.setdefault("serial.tools", serial_tools_stub)
 sys.modules.setdefault("serial.tools.list_ports", list_ports_stub)
 
 from adapters.uniden.bc125at_adapter import BC125ATAdapter  # noqa: E402
+from adapters.uniden.bcd325p2_adapter import BCD325P2Adapter  # noqa: E402
 import utilities.core.serial_utils as serial_utils  # noqa: E402
 
 
-def test_prg_toggles_flag(monkeypatch):
-    adapter = BC125ATAdapter()
+@pytest.mark.parametrize("adapter_cls", [BC125ATAdapter, BCD325P2Adapter])
+def test_prg_toggles_flag(monkeypatch, adapter_cls):
+    adapter = adapter_cls()
     adapter.in_program_mode = False
     monkeypatch.setattr(serial_utils, "send_command", lambda ser, cmd: "OK")
 
@@ -33,8 +36,9 @@ def test_prg_toggles_flag(monkeypatch):
     assert adapter.in_program_mode
 
 
-def test_epg_toggles_flag(monkeypatch):
-    adapter = BC125ATAdapter()
+@pytest.mark.parametrize("adapter_cls", [BC125ATAdapter, BCD325P2Adapter])
+def test_epg_toggles_flag(monkeypatch, adapter_cls):
+    adapter = adapter_cls()
     adapter.in_program_mode = True
     monkeypatch.setattr(serial_utils, "send_command", lambda ser, cmd: "OK")
 


### PR DESCRIPTION
## Summary
- centralize Uniden command transmission in `UnidenScannerAdapter`
- update BC125AT/BCD325P2 adapters to inherit shared command logic
- expand program mode tests to cover both adapters

## Testing
- `pre-commit run --files adapters/uniden/common/core.py adapters/uniden/bc125at_adapter.py adapters/uniden/bcd325p2_adapter.py tests/test_program_flag.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eae13ec448324b8545d9beada952e