### PR TITLE
Remove automatic root path injection

### DIFF
--- a/utilities/core/shared_utils.py
+++ b/utilities/core/shared_utils.py
@@ -20,10 +20,6 @@ def ensure_root_in_path():
         sys.path.insert(0, root_dir)
 
 
-# Call this function when the module is imported
-ensure_root_in_path()
-
-
 def diagnose_connection_issues():
     """Diagnose common connection problems with the scanner."""
     import serial.tools.list_ports


### PR DESCRIPTION
## Summary
- stop automatically inserting the repo root into `sys.path` when importing `utilities.core.shared_utils`
- rely on entry-point scripts for any needed path adjustments

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eaf6473d48324a6f5a9c760aebbbd