### PR TITLE
refactor: centralize read_response utility

### DIFF
--- a/tests/test_shared_utils.py
+++ b/tests/test_shared_utils.py
@@ -1,13 +1,11 @@
-"""Tests for shared utilities functions."""
-
+"""Tests for the centralized ``read_response`` function."""
 from unittest.mock import MagicMock
 
-from utilities.core.shared_utils import read_response
+from utilities.core.serial_utils import read_response
 
 
 def test_read_response_restores_timeout():
     """Ensure read_response restores the original timeout."""
-
     ser = MagicMock()
     ser.timeout = 5
     ser.read_until.return_value = b"RES\r"

--- a/utilities/core/shared_utils.py
+++ b/utilities/core/shared_utils.py
@@ -6,11 +6,11 @@ Serial communication helpers can be found in
 ``utilities.core.serial_utils``.
 """
 
-import logging
 import os
 import sys
 
 from utilities.core.command_library import ScannerCommand
+from utilities.core.serial_utils import read_response
 
 
 def ensure_root_in_path():
@@ -41,26 +41,9 @@ def diagnose_connection_issues():
     print("  4. Try reconnecting the scanner or using a different USB port.")
 
 
-def read_response(ser, timeout=1.0):
-    """Read a response from the serial port with a temporary timeout."""
-
-    original_timeout = ser.timeout
-    try:
-        ser.timeout = timeout
-        response = ser.read_until(b"\r").decode("utf-8").strip()
-        logging.debug(f"Shared utils received response: {response}")
-        return response
-    except Exception as e:  # pragma: no cover - error path
-        logging.error(f"Error reading response: {e}")
-        return ""
-    finally:
-        ser.timeout = original_timeout
-
-
 __all__ = [
     "ScannerCommand",
     "ensure_root_in_path",
     "diagnose_connection_issues",
     "read_response",
 ]
-


### PR DESCRIPTION
## Summary
- remove local `read_response` implementation in `shared_utils`
- update tests to use centralized `read_response`

## Testing
- `flake8 utilities/core/shared_utils.py tests/test_shared_utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ed85f1eec8324abc74a77ba6468cf