### PR TITLE
Inject connection manager for scanner connection

### DIFF
--- a/tests/test_repl_switch.py
+++ b/tests/test_repl_switch.py
@@ -63,9 +63,9 @@ def test_repl_switch(monkeypatch, capsys):
     # remember serial for id2 so we can check closed state
     ser2 = cm.get(id2)[0]
 
-    def fake_connect(scanner_id, machine_mode=False):
-        new_id = cm.open_connection("COM3", "X")
-        return cm.get(new_id)
+    def fake_connect(cm_arg, scanner_id, machine_mode=False):
+        new_id = cm_arg.open_connection("COM3", "X")
+        return cm_arg.get(new_id)
 
     monkeypatch.setattr("utilities.command.loop.connect_to_scanner", fake_connect)
 

--- a/tests/test_scanner_manager.py
+++ b/tests/test_scanner_manager.py
@@ -20,6 +20,7 @@ sys.modules.setdefault("serial.tools", serial_tools_stub)
 sys.modules.setdefault("serial.tools.list_ports", list_ports_stub)
 
 from utilities.scanner import manager  # noqa: E402
+from utilities.scanner.connection_manager import ConnectionManager  # noqa: E402
 
 
 def test_scan_for_scanners_no_devices(monkeypatch):
@@ -45,7 +46,8 @@ def test_scan_for_scanners_multiple(monkeypatch):
 
 def test_connect_to_scanner_invalid_input(monkeypatch):
     """Return an error when the scanner ID is not a number."""
-    assert manager.connect_to_scanner("abc") == (
+    cm = ConnectionManager()
+    assert manager.connect_to_scanner(cm, "abc") == (
         "STATUS:ERROR|CODE:INVALID_SCANNER_ID|MESSAGE:"
         "Scanner_ID_must_be_a_number"
     )
@@ -54,8 +56,10 @@ def test_connect_to_scanner_invalid_input(monkeypatch):
 def test_connect_to_scanner_no_scanners(monkeypatch):
     """Return an error when no scanners are detected."""
     monkeypatch.setattr(manager, "find_all_scanner_ports", lambda: [])
+    cm = ConnectionManager()
     assert (
-        manager.connect_to_scanner("1") == "STATUS:ERROR|CODE:NO_SCANNERS_FOUND"
+        manager.connect_to_scanner(cm, "1")
+        == "STATUS:ERROR|CODE:NO_SCANNERS_FOUND"
     )
 
 
@@ -64,8 +68,9 @@ def test_connect_to_scanner_id_out_of_range(monkeypatch):
     monkeypatch.setattr(
         manager, "find_all_scanner_ports", lambda: [("COM1", "X")]
     )
+    cm = ConnectionManager()
     assert (
-        manager.connect_to_scanner("2")
+        manager.connect_to_scanner(cm, "2")
         == "STATUS:ERROR|CODE:INVALID_SCANNER_ID|MAX_ID:1"
     )
 
@@ -86,7 +91,8 @@ def test_connect_to_scanner_unknown_uniden_model(monkeypatch):
         manager, "find_all_scanner_ports", lambda: [("COM1", "BC999XLT")]
     )
 
-    ser, adapter, commands, help_text = manager.connect_to_scanner("1")
+    cm = ConnectionManager()
+    ser, adapter, commands, help_text = manager.connect_to_scanner(cm, "1")
     assert isinstance(adapter, GenericUnidenAdapter)
     assert isinstance(ser, DummySerial)
 

--- a/utilities/command/loop.py
+++ b/utilities/command/loop.py
@@ -81,7 +81,9 @@ def main_loop(connection_manager, adapter=None, ser=None, commands=None, command
         return "\n".join(lines)
 
     def connect_cmd(scanner_id):
-        result = connect_to_scanner(scanner_id, machine_mode=machine_mode)
+        result = connect_to_scanner(
+            connection_manager, scanner_id, machine_mode=machine_mode
+        )
         if isinstance(result, tuple):
             refresh_active()
             conn_id = connection_manager.active_id

--- a/utilities/scanner/manager.py
+++ b/utilities/scanner/manager.py
@@ -314,16 +314,18 @@ def scan_for_scanners():
 
 
 def connect_to_scanner(
+    connection_manager,
     scanner_id,
     machine_mode=True,
     existing_commands=None,
     existing_command_help=None,
 ):
-    """
-    Connect to a specific scanner by its ID (from scan_for_scanners).
+    """Connect to a specific scanner by its ID (from :func:`scan_for_scanners`).
 
     Parameters
     ----------
+    connection_manager : ConnectionManager
+        Manager instance used to open and track the connection.
     scanner_id : str
         Scanner ID from the scan results.
     machine_mode : bool, optional
@@ -333,11 +335,13 @@ def connect_to_scanner(
     existing_command_help : dict, optional
         Existing command help dictionary to update.
 
-    Returns:
-        tuple
-            ``(ser, adapter, commands, command_help)`` if successful,
-            or an error message string if failed.
+    Returns
+    -------
+    tuple
+        ``(ser, adapter, commands, command_help)`` if successful, or an
+        error message string if failed.
     """
+
     try:
         scanner_id = int(scanner_id)
     except ValueError:


### PR DESCRIPTION
## Summary
- refactor `connect_to_scanner` to accept a `ConnectionManager` instance instead of relying on a module singleton
- pass the active `ConnectionManager` to `connect_to_scanner` in the command loop
- adjust tests to use an injected manager and updated signatures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ee5ffafb08324a7347f968cb4294e