### PR TITLE
Refactor scanner switch logic

### DIFF
--- a/utilities/command/loop.py
+++ b/utilities/command/loop.py
@@ -9,12 +9,23 @@ import logging
 from utilities.command.help_utils import show_help
 from utilities.command.parser import parse_command
 from utilities.io.readline_setup import initialize_readline
-from utilities.scanner.manager import connect_to_scanner, scan_for_scanners
+from utilities.scanner.manager import (
+    connect_to_scanner,
+    scan_for_scanners,
+    switch_scanner,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def main_loop(connection_manager, adapter=None, ser=None, commands=None, command_help=None, machine_mode=False):
+def main_loop(
+    connection_manager,
+    adapter=None,
+    ser=None,
+    commands=None,
+    command_help=None,
+    machine_mode=False,
+):
     """Interactive REPL for executing scanner commands.
 
     Parameters
@@ -89,7 +100,9 @@ def main_loop(connection_manager, adapter=None, ser=None, commands=None, command
             conn_id = connection_manager.active_id
             ser_, _, _, _ = connection_manager.get()
             if machine_mode:
-                return f"STATUS:OK|ACTION:CONNECTED|ID:{conn_id}|PORT:{ser_.port}"
+                return (
+                    f"STATUS:OK|ACTION:CONNECTED|ID:{conn_id}|PORT:{ser_.port}"
+                )
             return f"Connected to {ser_.port} [ID {conn_id}]"
         return result
 
@@ -141,35 +154,55 @@ def main_loop(connection_manager, adapter=None, ser=None, commands=None, command
                 current["model"] = val
         if current:
             scanners.append(current)
-        lines = [f"  {s['id']}. {s.get('port', '')} — {s.get('model', '')}" for s in scanners]
+        lines = [
+            f"  {s['id']}. {s.get('port', '')} — {s.get('model', '')}"
+            for s in scanners
+        ]
         return "\n".join(lines)
 
     def switch_cmd(scanner_id):
-        if connection_manager.active_id is not None:
-            connection_manager.close_connection(connection_manager.active_id)
-        return connect_cmd(scanner_id)
+        result = switch_scanner(
+            connection_manager,
+            scanner_id,
+            machine_mode=machine_mode,
+            connect_func=connect_to_scanner,
+        )
+        if isinstance(result, tuple):
+            refresh_active()
+            conn_id = connection_manager.active_id
+            ser_, _, _, _ = connection_manager.get()
+            if machine_mode:
+                return (
+                    f"STATUS:OK|ACTION:CONNECTED|ID:{conn_id}|PORT:{ser_.port}"
+                )
+            return f"Connected to {ser_.port} [ID {conn_id}]"
+        return result
 
-    global_commands.update({
-        "list": lambda: list_connections(),
-        "scan": lambda: scan_cmd(),
-        "connect": lambda arg: connect_cmd(arg),
-        "use": lambda arg: use_cmd(arg),
-        "close": lambda arg: close_cmd(arg),
-        "switch": lambda arg: switch_cmd(arg),
-    })
-    global_help.update({
-        "list": "List open connections",
-        "scan": "Detect connected scanners",
-        "connect": "Connect to scanner ID from 'scan'",
-        "use": "Select active connection",
-        "close": "Close a connection",
-        "switch": "Close current connection before opening another",
-    })
+    global_commands.update(
+        {
+            "list": lambda: list_connections(),
+            "scan": lambda: scan_cmd(),
+            "connect": lambda arg: connect_cmd(arg),
+            "use": lambda arg: use_cmd(arg),
+            "close": lambda arg: close_cmd(arg),
+            "switch": lambda arg: switch_cmd(arg),
+        }
+    )
+    global_help.update(
+        {
+            "list": "List open connections",
+            "scan": "Detect connected scanners",
+            "connect": "Connect to scanner ID from 'scan'",
+            "use": "Select active connection",
+            "close": "Close a connection",
+            "switch": "Close current connection before opening another",
+        }
+    )
 
     refresh_active()
 
-    global_commands["help"] = (
-        lambda arg="": show_help(commands, command_help, arg, adapter)
+    global_commands["help"] = lambda arg="": show_help(
+        commands, command_help, arg, adapter
     )
     global_help["help"] = "Show this help message"
     refresh_active()
@@ -186,7 +219,9 @@ def main_loop(connection_manager, adapter=None, ser=None, commands=None, command
                     print("STATUS:INFO|ACTION:EXIT")
                 break
 
-            command, args = parse_command(user_input, commands, connection_manager)
+            command, args = parse_command(
+                user_input, commands, connection_manager
+            )
             handler = commands.get(command)
 
             if handler:
@@ -195,7 +230,9 @@ def main_loop(connection_manager, adapter=None, ser=None, commands=None, command
 
                     if result is not None:
                         if isinstance(result, bytes):
-                            formatted_result = result.decode("ascii", errors="replace").strip()
+                            formatted_result = result.decode(
+                                "ascii", errors="replace"
+                            ).strip()
                         elif isinstance(result, (int, float)):
                             formatted_result = str(result)
                         else:
@@ -205,18 +242,27 @@ def main_loop(connection_manager, adapter=None, ser=None, commands=None, command
                             if formatted_result.startswith("STATUS:"):
                                 print(formatted_result)
                             else:
-                                is_error = formatted_result.lower().startswith("error")
+                                is_error = formatted_result.lower().startswith(
+                                    "error"
+                                )
                                 status = "ERROR" if is_error else "OK"
-                                msg = formatted_result.replace(" ", "_").replace(":", "_")
+                                msg = formatted_result.replace(
+                                    " ", "_"
+                                ).replace(":", "_")
                                 print(
-                                    f"STATUS:{status}|COMMAND:{command}|RESULT:{msg}"
+                                    f"STATUS:{status}|COMMAND:{command}|"
+                                    f"RESULT:{msg}"
                                 )
                         else:
                             if formatted_result.startswith("STATUS:"):
                                 parts = formatted_result.split("|")
                                 for part in parts:
-                                    if part.startswith("MESSAGE:") or part.startswith("RESULT:"):
-                                        value = part.split(":", 1)[1].replace("_", " ")
+                                    if part.startswith(
+                                        "MESSAGE:"
+                                    ) or part.startswith("RESULT:"):
+                                        value = part.split(":", 1)[1].replace(
+                                            "_", " "
+                                        )
                                         print(value)
                                         break
                                 else:
@@ -228,12 +274,17 @@ def main_loop(connection_manager, adapter=None, ser=None, commands=None, command
                     logger.error(f"Command error: {str(e)}", exc_info=True)
                     if machine_mode:
                         error_msg = str(e).replace(" ", "_").replace(":", "_")
-                        print(f"STATUS:ERROR|COMMAND:{command}|MESSAGE:{error_msg}")
+                        print(
+                            f"STATUS:ERROR|COMMAND:{command}|"
+                            f"MESSAGE:{error_msg}"
+                        )
                     else:
                         print(f"[Error] {e}")
             else:
                 if machine_mode:
-                    print(f"STATUS:ERROR|CODE:UNKNOWN_COMMAND|COMMAND:{command}")
+                    print(
+                        f"STATUS:ERROR|CODE:UNKNOWN_COMMAND|COMMAND:{command}"
+                    )
                 else:
                     print("Unknown command. Type 'help' for options.")
         except KeyboardInterrupt:
@@ -242,7 +293,9 @@ def main_loop(connection_manager, adapter=None, ser=None, commands=None, command
             else:
                 print("\nUse 'exit' to quit the program.")
         except Exception as e:
-            logger.error(f"Unexpected error in command loop: {e}", exc_info=True)
+            logger.error(
+                f"Unexpected error in command loop: {e}", exc_info=True
+            )
             if machine_mode:
                 error_msg = str(e).replace(" ", "_").replace(":", "_")
                 print(f"STATUS:ERROR|CODE:UNEXPECTED|MESSAGE:{error_msg}")

--- a/utilities/scanner/__init__.py
+++ b/utilities/scanner/__init__.py
@@ -8,13 +8,13 @@ detection, and control that are not specific to any single scanner model.
 from utilities.scanner.factory import get_scanner_adapter
 from utilities.scanner.manager import (
     connect_to_scanner,
-    handle_switch_command,
     scan_for_scanners,
+    switch_scanner,
 )
 
 __all__ = [
     "connect_to_scanner",
-    "handle_switch_command",
     "scan_for_scanners",
+    "switch_scanner",
     "get_scanner_adapter",
 ]

--- a/utilities/scanner/manager.py
+++ b/utilities/scanner/manager.py
@@ -1,18 +1,12 @@
-"""
-Scanner management utilities.
+"""Scanner management utilities.
 
 This module contains functions for managing scanner connections and switching.
 """
 
 import logging
+import serial  # noqa: F401
 
-import serial
-from functools import partial
-
-from utilities.core.command_registry import build_command_table
 from utilities.scanner.backend import find_all_scanner_ports
-from utilities.io.timeout_utils import with_timeout
-from utilities.scanner.factory import get_scanner_adapter
 from utilities.scanner.connection_manager import ConnectionManager
 
 logger = logging.getLogger(__name__)
@@ -21,184 +15,18 @@ logger = logging.getLogger(__name__)
 connection_manager = ConnectionManager()
 
 
-def switch_scanner(
-    current_ser, current_adapter, machine_mode=False, direct_scanner_id=None
-):
-    """
-    Switch to a different scanner without exiting the application.
-
-    Parameters:
-        current_ser (serial.Serial): Current serial connection to close.
-        current_adapter: Current adapter instance.
-        machine_mode (bool): Whether to use machine-friendly output.
-        direct_scanner_id (int, optional): Direct scanner ID to connect to,
-            bypassing scan selection.
-
-    Returns:
-        tuple: (conn_id, new_ser, new_adapter, new_commands, new_command_help)
-        or None if canceled/error
-    """
-
-    active_conn_id = connection_manager.active_id
-
-    if machine_mode:
-        print("STATUS:INFO|ACTION:DETECTING_SCANNERS")
-    else:
-        print("\nDetecting available scanners...")
-
-    detected = find_all_scanner_ports()
-
-    if not detected:
-        if machine_mode:
-            print("STATUS:ERROR|CODE:NO_SCANNERS_FOUND")
-        else:
-            print("No scanners found. Check connections and try again.")
-        return None
-
-    # Display available scanners
-    if machine_mode:
-        print(f"STATUS:INFO|SCANNERS_FOUND:{len(detected)}")
-        for idx, (port, model) in enumerate(detected, 1):
-            print(f"SCANNER:{idx}|PORT:{port}|MODEL:{model}")
-    else:
-        print("\nAvailable scanners:")
-        for idx, (port, model) in enumerate(detected, 1):
-            print(f"  {idx}. {port} — {model}")
-
-    # Get user selection or use direct scanner ID
-    try:
-        if direct_scanner_id is not None:
-            selection = int(direct_scanner_id)
-            if not (1 <= selection <= len(detected)):
-                if machine_mode:
-                    print(
-                        "STATUS:ERROR|CODE:INVALID_SCANNER_ID|MAX_ID:"
-                        f"{len(detected)}"
-                    )
-                else:
-                    print(
-                        f"Invalid scanner ID: {selection}. Must be between 1 "
-                        f"and {len(detected)}."
-                    )
-                return None
-        elif machine_mode:
-            selection = 1
-            print(f"STATUS:INFO|AUTO_SELECTED:{selection}")
-        else:
-            selection = input("\nSelect scanner (enter number or 0 to cancel): ")
-            if selection.strip() == "0" or not selection.strip():
-                print("Switch canceled, reconnecting to current scanner...")
-                return None
-            try:
-                selection = int(selection)
-            except ValueError:
-                print("Invalid input, reconnecting to current scanner...")
-                return None
-            if not (1 <= selection <= len(detected)):
-                print("Invalid selection, reconnecting to current scanner...")
-                return None
-    except Exception as e:
-        if machine_mode:
-            error_msg = str(e).replace(" ", "_").replace(":", "_")
-            print(f"STATUS:ERROR|CODE:SELECTION_ERROR|MESSAGE:{error_msg}")
-        else:
-            print(f"Error selecting scanner: {e}")
-        return None
-
-    # Connect to selected scanner
-    port, scanner_model = detected[selection - 1]
-
-    try:
-        # Close the current active connection before opening a new one
-        if active_conn_id is not None:
-            try:
-                connection_manager.close_connection(active_conn_id)
-            except Exception as exc:
-                logger.error(f"Error closing active connection {active_conn_id}: {exc}")
-        if current_ser and current_ser.is_open:
-            try:
-                current_ser.close()
-            except Exception as exc:
-                logger.error(f"Error closing current connection: {exc}")
-
-        conn_id = connection_manager.open_connection(
-            port, scanner_model, machine_mode
-        )
-        new_ser, new_adapter, new_commands, new_command_help = connection_manager.get(
-            conn_id
-        )
-
-        if machine_mode:
-            print(
-                f"STATUS:OK|ACTION:SWITCHED|PORT:{port}|MODEL:{scanner_model}|ID:{conn_id}"
-            )
-        else:
-            print(
-                f"\nSuccessfully switched to {port} ({scanner_model}) [ID {conn_id}]"
-            )
-        return (
-            conn_id,
-            new_ser,
-            new_adapter,
-            new_commands,
-            new_command_help,
-        )
-
-    except Exception as e:
-        logger.error(f"Error connecting to new scanner: {e}")
-        if machine_mode:
-            error_msg = str(e).replace(" ", "_").replace(":", "_")
-            print(f"STATUS:ERROR|CODE:CONNECTION_FAILED|MESSAGE:{error_msg}")
-        else:
-            print(f"Error connecting to new scanner: {e}")
-        return None
-
-
-def handle_switch_command(
-    ser, adapter, commands, command_help, machine_mode, scanner_id=None
-):
-    """
-    Switch command handler for the scanner.
-
-    Handler for the switch command that switches scanners.
-
-    Parameters:
-        ser (serial.Serial): Current serial connection.
-        adapter: Current adapter instance.
-        commands (dict): Dictionary of available commands.
-        command_help (dict): Dictionary of help texts for commands.
-        machine_mode (bool): Whether to use machine-friendly output.
-        scanner_id (str, optional): Scanner ID to directly connect to.
-    """
-    direct_id = None
-    if scanner_id:
-        try:
-            direct_id = int(scanner_id)
-        except ValueError:
-            if machine_mode:
-                return (
-                    "STATUS:ERROR|CODE:INVALID_SCANNER_ID|"
-                    "MESSAGE:Scanner_ID_must_be_a_number"
-                )
-            else:
-                return f"Invalid scanner ID: {scanner_id}. Must be a number."
-
-    result = switch_scanner(ser, adapter, machine_mode, direct_id)
-    if result:
-        # Return the new connection info to be handled in main_loop
-        return result
-    return "Scanner switch canceled or failed"
-
-
 def detect_and_connect_scanner(machine_mode=False):
-    """
-    Detect available scanners and connect to one selected by the user.
+    """Detect available scanners and connect to one selected by the user.
 
-    Parameters:
-        machine_mode (bool): Whether to use machine-friendly output.
+    Parameters
+    ----------
+    machine_mode : bool
+        Whether to use machine-friendly output.
 
-    Returns:
-        tuple: (conn_id, ser, adapter, commands, command_help) or
+    Returns
+    -------
+    tuple
+        (conn_id, ser, adapter, commands, command_help) or
         (None, None, None, None, None) if failed
     """
     if machine_mode:
@@ -272,7 +100,8 @@ def detect_and_connect_scanner(machine_mode=False):
 
         if machine_mode:
             print(
-                f"STATUS:OK|ACTION:CONNECTED|PORT:{port}|MODEL:{scanner_model}|ID:{conn_id}"
+                f"STATUS:OK|ACTION:CONNECTED|PORT:{port}|"
+                f"MODEL:{scanner_model}|ID:{conn_id}"
             )
         else:
             print(f"Connected to {port} ({scanner_model}) [ID {conn_id}]")
@@ -290,14 +119,15 @@ def detect_and_connect_scanner(machine_mode=False):
 
 
 def scan_for_scanners():
-    """
-    Scan for available scanners and return the list.
+    """Scan for available scanners and return the list.
 
     This command is primarily for machine mode to list scanners
     without automatically connecting.
 
-    Returns:
-        str: Machine-readable list of available scanners
+    Returns
+    -------
+    str
+        Machine-readable list of available scanners
     """
     logger.info("Scanning for connected scanners")
 
@@ -320,7 +150,7 @@ def connect_to_scanner(
     existing_commands=None,
     existing_command_help=None,
 ):
-    """Connect to a specific scanner by its ID (from :func:`scan_for_scanners`).
+    """Connect to a specific scanner by its ID.
 
     Parameters
     ----------
@@ -329,7 +159,7 @@ def connect_to_scanner(
     scanner_id : str
         Scanner ID from the scan results.
     machine_mode : bool, optional
-        Whether to initialize the adapter in machine mode. Defaults to ``True``.
+        Whether to initialize the adapter in machine mode. Defaults to True.
     existing_commands : dict, optional
         Existing commands dictionary to update.
     existing_command_help : dict, optional
@@ -341,7 +171,6 @@ def connect_to_scanner(
         ``(ser, adapter, commands, command_help)`` if successful, or an
         error message string if failed.
     """
-
     try:
         scanner_id = int(scanner_id)
     except ValueError:
@@ -364,9 +193,7 @@ def connect_to_scanner(
 
     try:
         conn_id = connection_manager.open_connection(
-            port,
-            scanner_model,
-            machine_mode,
+            port, scanner_model, machine_mode
         )
         ser, adapter, commands, command_help = connection_manager.get(conn_id)
 
@@ -380,3 +207,32 @@ def connect_to_scanner(
         logger.error(f"Error communicating with scanner: {e}")
         error_msg = str(e).replace(" ", "_").replace(":", "_")
         return f"STATUS:ERROR|CODE:COMMUNICATION_FAILED|MESSAGE:{error_msg}"
+
+
+def switch_scanner(
+    connection_manager,
+    scanner_id,
+    machine_mode=True,
+    connect_func=connect_to_scanner,
+):
+    """Close the active connection and connect to a new scanner by ID.
+
+    Parameters
+    ----------
+    connection_manager : ConnectionManager
+        Manager instance used to manage the connections.
+    scanner_id : str or int
+        Identifier of the scanner to switch to.
+    machine_mode : bool, optional
+        Whether to use machine-friendly output. Defaults to True.
+
+    Returns
+    -------
+    tuple or str
+        Result of :func:`connect_to_scanner`.
+    """
+    if connection_manager.active_id is not None:
+        connection_manager.close_connection(connection_manager.active_id)
+    return connect_func(
+        connection_manager, scanner_id, machine_mode=machine_mode
+    )


### PR DESCRIPTION
## Summary
- streamline scanner switching through new `switch_scanner` helper that relies on `ConnectionManager`
- expose `switch_scanner` for external use and update REPL to use shared helper
- remove legacy switch handlers and redundant serial port closures

## Testing
- `pytest`
- `pre-commit run --files utilities/scanner/__init__.py utilities/scanner/manager.py utilities/command/loop.py` *(fails: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688ee714f0808324b37aaae037d2d011