### PR TITLE
Clarify serial port examples across tools

### DIFF
--- a/tools/debug_volume_control.py
+++ b/tools/debug_volume_control.py
@@ -113,7 +113,7 @@ def main():
         description="Debug volume and squelch controls"
     )
     parser.add_argument(
-        '--port', required=True, help='Serial port (e.g., COM3)'
+        '--port', required=True, help='Serial port (e.g., COM3 or /dev/ttyUSB0)'
     )
     parser.add_argument('--model', default="Unknown", help='Scanner model')
     parser.add_argument(

--- a/tools/scanner_diagnostics.py
+++ b/tools/scanner_diagnostics.py
@@ -76,7 +76,9 @@ def main():
     parser = argparse.ArgumentParser(
         description="Scanner communication diagnostics tool"
     )
-    parser.add_argument('--port', help='Serial port to use (e.g., COM3)')
+    parser.add_argument(
+        '--port', help='Serial port to use (e.g., COM3 or /dev/ttyUSB0)'
+    )
     parser.add_argument('--model', help='Scanner model (e.g., BCD325P2)')
     parser.add_argument(
         '--scan', action='store_true', help='Scan for available ports'

--- a/tools/volume_range_test.py
+++ b/tools/volume_range_test.py
@@ -91,7 +91,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="Test scanner volume range support"
     )
-    parser.add_argument('port', help='Serial port (e.g., COM3)')
+    parser.add_argument('port', help='Serial port (e.g., COM3 or /dev/ttyUSB0)')
     parser.add_argument(
         '--baudrate', type=int, default=115200, help='Baud rate'
     )


### PR DESCRIPTION
## Summary
- Mention `/dev/ttyUSB0` alongside `COM3` in serial port CLI help messages
- Replace remaining "Serial port (e.g., COM3)" references

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f853b92dc8324b4346bf1521a87fa