### PR TITLE
Replace COM port references with serial ports in GUI warnings

### DIFF
--- a/scanner_gui/main.py
+++ b/scanner_gui/main.py
@@ -31,7 +31,7 @@ def main():
     # Import ScannerGUI here, after QApplication is created
     from scanner_gui.gui.scanner_gui import ScannerGUI
 
-    # Show warning if COM ports are inaccessible
+    # Show warning if serial ports are inaccessible
     busy_ports = []
     for port in list_ports.comports():
         try:
@@ -43,7 +43,7 @@ def main():
             busy_ports.append((port.device, str(e)))
 
     if busy_ports:
-        warning_msg = "Some COM ports are inaccessible and can't be used:\n\n"
+        warning_msg = "Some serial ports are inaccessible and can't be used:\n\n"
         for port, error in busy_ports:
             warning_msg += f"• {port}: {error}\n"
         warning_msg += (


### PR DESCRIPTION
## Summary
- use platform-neutral "serial port" terminology in GUI warning comments and messages

## Testing
- `pre-commit run --files scanner_gui/main.py` *(fails: unable to access https://github.com/pre-commit/pre-commit-hooks/)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f866f80588324a15d97b9a3072681