### PR TITLE
Fix serial port scanning on Linux

### DIFF
--- a/tests/test_backend_port_generator.py
+++ b/tests/test_backend_port_generator.py
@@ -1,0 +1,41 @@
+import types
+
+from utilities.scanner import backend
+
+
+class DummySerial:
+    def __init__(self, port, *args, **kwargs):
+        self.port = port
+        self.in_waiting = 1
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def write(self, data):
+        self.last_write = data
+
+    def reset_input_buffer(self):
+        pass
+
+
+def test_find_all_scanner_ports_handles_generator(monkeypatch):
+    """find_all_scanner_ports should handle generator returned by comports."""
+
+    # Patch serial.Serial
+    monkeypatch.setattr(backend.serial, "Serial", DummySerial, raising=False)
+
+    # Patch wait_for_data and read_response to simulate a scanner replying
+    monkeypatch.setattr(backend, "wait_for_data", lambda ser, max_wait=0.3: True)
+    monkeypatch.setattr(backend, "read_response", lambda ser, timeout=1.0: "MDL,MOCK")
+
+    # Prepare a generator for comports
+    def fake_comports():
+        yield types.SimpleNamespace(device="/dev/ttyUSB0", description="Mock Port")
+
+    monkeypatch.setattr(backend.list_ports, "comports", fake_comports)
+
+    detected = backend.find_all_scanner_ports()
+    assert detected == [("/dev/ttyUSB0", "MOCK")]

--- a/utilities/scanner/backend.py
+++ b/utilities/scanner/backend.py
@@ -16,7 +16,11 @@ def find_all_scanner_ports(baudrate=115200, timeout=0.5, max_retries=2, skip_por
     detected = []
     retries = 0
     while retries < max_retries:
-        ports = list_ports.comports()
+        # list_ports.comports() returns an iterable that can be exhausted after
+        # a single pass on some platforms (e.g. Linux).  Convert it to a list so
+        # we can iterate over the available ports multiple times within this
+        # loop without losing data.
+        ports = list(list_ports.comports())
         logging.info(f"Available ports: {len(ports)}")
         for port_info in ports:
             logging.info(


### PR DESCRIPTION
## Summary
- handle generator exhaustion when scanning serial ports on Linux
- add regression test for generator-based port lists

## Testing
- `pytest`
- `pre-commit run --files utilities/scanner/backend.py tests/test_backend_port_generator.py` *(fails: command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_688f8e17249c8324a1c6d10819abbaee