### PR TITLE
feat: include hid device scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ pip install -r requirements.txt
 
 4. Ensure the required scanner models are connected via serial ports.
 
+## Enabling HID Devices
+
+Some scanners appear as HID devices rather than traditional serial ports. To
+use these devices:
+
+1. Install the optional [`hid`](https://pypi.org/project/hid/) library:
+   `pip install hid`
+2. Ensure `/dev/usb/hiddev*` paths are accessible. On Linux this may require
+   additional drivers or udev rules.
+
+Once configured, diagnostics tools will list HID paths alongside serial ports.
+
 ## Usage
 
 Run the CLI version:

--- a/tools/scanner_diagnostics.py
+++ b/tools/scanner_diagnostics.py
@@ -8,6 +8,7 @@ commands and displaying available adapter methods.
 import argparse
 import logging
 import time
+import glob
 
 import serial
 from serial.tools import list_ports
@@ -81,15 +82,23 @@ def main():
     )
     parser.add_argument('--model', help='Scanner model (e.g., BCD325P2)')
     parser.add_argument(
-        '--scan', action='store_true', help='Scan for available ports'
+        '--scan', action='store_true', help='Scan for available ports or HID devices'
     )
     args = parser.parse_args()
 
     if args.scan:
-        print("=== Scanning for available ports ===")
+        print("=== Scanning for available devices ===")
         ports = list(list_ports.comports())
         for port in ports:
             print(f"{port.device}: {port.description}")
+
+        hid_paths = glob.glob("/dev/usb/hiddev*")
+        for hid_path in hid_paths:
+            print(
+                f"{hid_path}: HID device (may require additional setup or drivers)"
+            )
+        if hid_paths:
+            print("See README section 'Enabling HID Devices' for more details.")
         return
 
     if not args.port:

--- a/utilities/core/shared_utils.py
+++ b/utilities/core/shared_utils.py
@@ -8,6 +8,7 @@ Serial communication helpers can be found in
 
 import os
 import sys
+import glob
 
 from utilities.core.command_library import ScannerCommand
 from utilities.core.serial_utils import read_response
@@ -26,19 +27,30 @@ def diagnose_connection_issues():
 
     print("\nDiagnosing connection issues...")
     ports = list(serial.tools.list_ports.comports())
-    if not ports:
-        print("No serial ports detected. Ensure the scanner is connected.")
+    hid_paths = glob.glob("/dev/usb/hiddev*")
+    if not ports and not hid_paths:
+        print("No serial or HID devices detected. Ensure the scanner is connected.")
         return
 
-    print("Available serial ports:")
-    for port in ports:
-        print(f"  - {port.device}: {port.description}")
+    if ports:
+        print("Available serial ports:")
+        for port in ports:
+            print(f"  - {port.device}: {port.description}")
+    else:
+        print("No serial ports detected.")
+
+    if hid_paths:
+        print("Available HID devices (may require additional setup or drivers):")
+        for path in hid_paths:
+            print(f"  - {path}")
+        print("See README section 'Enabling HID Devices' for more details.")
 
     print("\nSuggestions:")
     print("  1. Verify the scanner is powered on.")
     print("  2. Check that the correct port is selected.")
     print("  3. Ensure no other application is using the port.")
     print("  4. Try reconnecting the scanner or using a different USB port.")
+    print("  5. If using a HID device, install any required drivers or enable permissions.")
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- scan and display HID devices alongside serial ports in diagnostics
- add HID device enumeration to connection troubleshooting
- document how to enable HID devices

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f9285946c83249163adbb16dd9897