### PR TITLE
Add HID dependency to requirements files

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,3 +25,4 @@ pyflakes==3.3.2
 pytest==8.3.5
 pyreadline3==3.5.4
 virtualenv==20.30.0
+hid==1.0.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PyQt6-Qt6==6.9.0
 PyQt6_sip==13.10.0
 pyserial==3.5
 PyYAML==6.0.2
+hid==1.0.*


### PR DESCRIPTION
## Summary
- add HID package to runtime requirements
- include HID in development requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies iso8601==2.1.0; CONNECT tunnel failed: 403)*
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies hid==1.0.*; CONNECT tunnel failed: 403)*
- `pre-commit run --files requirements.txt requirements-dev.txt` *(fails: unable to access https://github.com/pre-commit/pre-commit-hooks/; CONNECT tunnel failed: 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f9eff22a08324b601489312f66814