### PR TITLE
Add optional HID extra and document installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ python -m venv .venv
 pip install -r requirements.txt
 ```
 
+To include optional HID support, install the package with the `hid` extra:
+
+```bash
+pip install .[hid]
+```
+
 4. Ensure the required scanner models are connected via serial ports.
 
 ## Enabling HID Devices on Linux
@@ -124,10 +130,11 @@ python tools/scanner_diagnostics.py --scan
 
 ### Option 2: Use Native HID Support
 
-1. Install the optional [`hid`](https://pypi.org/project/hid/) library:
+1. Install the optional [`hid`](https://pypi.org/project/hid/) library via the
+   `hid` extra:
 
    ```bash
-   pip install hid
+   pip install .[hid]
    ```
 
 2. Grant your user access to HID devices:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,6 @@ include_trailing_comma = true
 use_parentheses = true
 ensure_newline_before_comments = true
 skip_glob = [".venv/*", ".pytest_cache/*", ".github/*", "__pycache__/*"]
+
+[project.optional-dependencies]
+hid = ["hid==1.0.*"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,7 @@ force_grid_wrap = 0
 include_trailing_comma = true
 use_parentheses = true
 ensure_newline_before_comments = true
+
+[options.extras_require]
+hid =
+    hid==1.0.*


### PR DESCRIPTION
## Summary
- add `hid` optional dependency group
- reference `hid` extra in build config
- document installing hid extra in README

## Testing
- `pre-commit run --files pyproject.toml setup.cfg README.md` *(fails: unable to access 'https://github.com/pre-commit/pre-commit-hooks/')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fa0832ce8832486f3e22d82e3c751