### PR TITLE
Add HID setup script and quick-start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,20 @@ pip install .[hid]
 Some scanners, such as the **Uniden BC125AT**, may appear as HID devices at
 `/dev/usb/hiddev*` rather than traditional serial ports.
 
+### One-command Setup
+
+Run the helper script to load the USB serial driver and grant HID access:
+
+```bash
+tools/setup_hid.sh
+```
+
+Log out and back in, then verify detection with:
+
+```bash
+python tools/scanner_diagnostics.py --scan
+```
+
 ### Option 1: Load USB Serial Driver
 
 Expose the scanner as a serial port by loading the USB serial driver:

--- a/tools/setup_hid.sh
+++ b/tools/setup_hid.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+sudo modprobe usbserial vendor=0x1965 product=0x0017
+sudo usermod -aG plugdev "$USER"
+
+echo "Log out and back in for group changes to take effect."
+echo "Then run: python tools/scanner_diagnostics.py --scan"


### PR DESCRIPTION
## Summary
- add tools/setup_hid.sh for Linux HID setup
- document one-command HID setup option in README

## Testing
- `pre-commit run --files tools/setup_hid.sh README.md` *(fails: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fa29b9f008324bc513709fb8a1fc9