### PR TITLE
Add S-meter support for BC125AT

### DIFF
--- a/adapters/uniden/bc125at/status_info.py
+++ b/adapters/uniden/bc125at/status_info.py
@@ -118,12 +118,18 @@ def read_status(self, ser):
 
 
 def read_s_meter(self, ser):
-    """S-meter (not supported on BC125AT).
+    """Read S-meter value using the RSSI command.
 
     Args:
         ser: Serial connection to the scanner.
 
     Returns:
-        str: Error message indicating feature not supported.
+        str: Normalized RSSI reading or error message.
     """
-    return self.feedback(False, "S-Meter not supported on BC125AT")
+    try:
+        strength = self.read_rssi(ser)
+        if strength is not None:
+            return self.feedback(True, f"S-Meter: {strength}")
+    except Exception:
+        pass
+    return self.feedback(False, "Error reading S-meter")


### PR DESCRIPTION
## Summary
- read the BC125AT's signal strength via existing `read_rssi` helper
- return normalized RSSI value when `get signal` is requested
- include minimal error handling similar to `read_rssi`

## Testing
- `pytest tests/test_command_registry.py -q`
- `pytest tests/test_bc125at_band_scope.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fdd78386c832493242123b4b839cc