### PR TITLE
Add search-based band scope option for BC125AT

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,21 @@ programs custom search range 1 using `CSP` and enables only that range with
 command uses the preset limits in 100‑Hz units (e.g. `01080000` for 108 MHz)
 to align with the scanner's expected format.
 
+#### BC125AT Search-Based Sweep
+
+For the BC125AT, appending `search` to the `band scope` command performs a
+slower sweep that polls the `PWR` command while the scanner runs a custom
+search between the preset limits:
+
+```text
+> band scope air search
+```
+
+The adapter programs range 1 using `CSP`/`CSG`, starts scanning, and records a
+frequency/RSSI pair for each step. This method makes only a single pass across
+the band and ignores the sweep-count parameter, so it is best suited for quick
+checks rather than long captures.
+
 ### Band Scope Streaming
 
 Band scope status can be streamed using the `CSC` command. When activated the

--- a/tests/test_bc125at_band_scope.py
+++ b/tests/test_bc125at_band_scope.py
@@ -18,6 +18,7 @@ sys.modules.setdefault("serial.tools", serial_tools_stub)
 sys.modules.setdefault("serial.tools.list_ports", list_ports_stub)
 
 from adapters.uniden.bc125at_adapter import BC125ATAdapter  # noqa: E402
+from utilities.core.command_registry import build_command_table  # noqa: E402
 
 
 def test_bc125at_sweep_parses_units(monkeypatch):
@@ -77,3 +78,33 @@ def test_bc125at_configure_band_scope_sets_width(monkeypatch):
     result = adapter.configure_band_scope(None, "air")
     assert adapter.band_scope_width == 3362
     assert result == "OK"
+
+
+def test_bc125at_band_scope_search_flag(monkeypatch):
+    adapter = BC125ATAdapter()
+    monkeypatch.setattr(adapter, "_calc_band_scope_width", lambda span, bw: 3)
+
+    pwr_responses = [
+        "PWR,10,01080000",
+        "PWR,20,01080010",
+        "PWR,30,01080020",
+    ]
+
+    def send_command_stub(ser, cmd):
+        if cmd.startswith("CSP"):
+            return "OK"
+        if cmd.startswith("CSG"):
+            return "OK"
+        if cmd == "PWR":
+            return pwr_responses.pop(0)
+        return "OK"
+
+    monkeypatch.setattr(adapter, "send_command", send_command_stub)
+    monkeypatch.setattr(adapter, "start_scanning", lambda ser: None)
+    monkeypatch.setattr(adapter, "stop_scanning", lambda ser: None)
+
+    commands, _ = build_command_table(adapter, None)
+    output = commands["band scope"](None, adapter, "air search")
+    lines = output.splitlines()
+    assert len(lines) == 4  # 3 records + summary
+    assert lines[-1].startswith("center=")

--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -191,8 +191,8 @@ def build_command_table(adapter, ser):
             "(Not available for this scanner model)"
         )
 
-    # Band scope (CSC streaming)
-    if hasattr(adapter, 'stream_custom_search'):
+    # Band scope (CSC streaming or search sweep)
+    if hasattr(adapter, 'stream_custom_search') or hasattr(adapter, 'search_band_scope'):
         logging.debug("Registering 'band scope' command")
 
         def band_scope(ser_, adapter_, arg=""):
@@ -200,6 +200,7 @@ def build_command_table(adapter, ser):
             sweep_count = 1
             mode = "list"
             preset = None
+            use_search_sweep = False
 
             # Handle Close Call subcommands: "band scope <preset> cc search|log"
             if len(parts) >= 2 and parts[1].lower() == "cc":
@@ -242,6 +243,9 @@ def build_command_table(adapter, ser):
                 if lower in ("list", "hits"):
                     mode = lower
                     continue
+                if lower == "search":
+                    use_search_sweep = True
+                    continue
                 if not first_non_flag_found:
                     first_non_flag_found = True
                     try:
@@ -262,41 +266,53 @@ def build_command_table(adapter, ser):
                     except ValueError:
                         pass
 
-            if preset and hasattr(adapter_, "configure_band_scope"):
-                result = adapter_.configure_band_scope(ser_, preset)
-                if result and "OK" not in result.upper():
-                    return result
-
-            if getattr(adapter_, "in_program_mode", False):
-                return (
-                    "Scanner is in programming mode. "
-                    "Run 'send EPG' then rerun 'band scope'."
-                )
-
-            width = getattr(adapter_, "band_scope_width", None) or 1024
-            record_count = width * sweep_count
-
             records = []
-            debug_mode = logging.getLogger().isEnabledFor(logging.DEBUG)
-            show_progress = sys.stdout.isatty()
-            spinner = itertools.cycle("|/-\\") if show_progress else None
-            processed = 0
-            for rssi, freq, _ in adapter_.stream_custom_search(
-                ser_, record_count, debug=debug_mode
-            ):
-                records.append((rssi, freq))
-                if show_progress:
-                    processed += 1
-                    ch = next(spinner)
-                    percent = processed / record_count * 100
-                    sys.stdout.write(f"\r{ch} {percent:5.1f}%")
-                    sys.stdout.flush()
-            if show_progress:
-                sys.stdout.write("\r")
-                sys.stdout.flush()
 
-            if not records:
-                return "No band scope data received"
+            if use_search_sweep:
+                if not hasattr(adapter_, "search_band_scope"):
+                    return "Search-based sweep not supported on this scanner"
+                if not preset:
+                    return "Usage: band scope <preset> search"
+                for _ in range(sweep_count):
+                    sweep_records = adapter_.search_band_scope(ser_, preset)
+                    records.extend(sweep_records)
+                if not records:
+                    return "No band scope data received"
+            else:
+                if preset and hasattr(adapter_, "configure_band_scope"):
+                    result = adapter_.configure_band_scope(ser_, preset)
+                    if result and "OK" not in result.upper():
+                        return result
+
+                if getattr(adapter_, "in_program_mode", False):
+                    return (
+                        "Scanner is in programming mode. "
+                        "Run 'send EPG' then rerun 'band scope'."
+                    )
+
+                width = getattr(adapter_, "band_scope_width", None) or 1024
+                record_count = width * sweep_count
+
+                debug_mode = logging.getLogger().isEnabledFor(logging.DEBUG)
+                show_progress = sys.stdout.isatty()
+                spinner = itertools.cycle("|/-\\") if show_progress else None
+                processed = 0
+                for rssi, freq, _ in adapter_.stream_custom_search(
+                    ser_, record_count, debug=debug_mode
+                ):
+                    records.append((rssi, freq))
+                    if show_progress:
+                        processed += 1
+                        ch = next(spinner)
+                        percent = processed / record_count * 100
+                        sys.stdout.write(f"\r{ch} {percent:5.1f}%")
+                        sys.stdout.flush()
+                if show_progress:
+                    sys.stdout.write("\r")
+                    sys.stdout.flush()
+
+                if not records:
+                    return "No band scope data received"
 
             freqs = [f for _, f in records]
             if freqs:
@@ -358,8 +374,9 @@ def build_command_table(adapter, ser):
         COMMANDS["band scope"] = band_scope
         COMMAND_HELP["band scope"] = (
             "Stream band scope data or manage Close Call. Usage: band scope <preset> "
-            "[sweeps] [list|hits] | band scope <preset> cc search|log. "
-            "During 'cc search', press Enter or 'q' to stop."
+            "[sweeps] [list|hits] [search] | band scope <preset> cc search|log. "
+            "During 'cc search', press Enter or 'q' to stop. "
+            "Append 'search' to use a PWR-based sweep on models without CSC streaming."
         )
 
         logging.debug("Registering 'band sweep' command")


### PR DESCRIPTION
## Summary
- add `search_band_scope` to BC125AT adapter to sweep using custom search range and PWR polling
- support `band scope <preset> search` flag in command registry
- document BC125AT search-based band scope usage and add tests

## Testing
- `pytest tests/test_bc125at_band_scope.py::test_bc125at_band_scope_search_flag -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688fe88e43d88324bb48ab035e56cd07