### PR TITLE
fix: don't treat empty dicts as failed connection

### DIFF
--- a/main.py
+++ b/main.py
@@ -100,8 +100,8 @@ def main():
                 detect_and_connect_scanner(machine_mode)
             )
 
-            if not all([ser, adapter, commands, command_help]):
-                # If connection was not successful
+            if any(v is None for v in (ser, adapter, commands, command_help)):
+                # If any required connection detail is missing
                 print(
                     "Failed to connect to scanner. Please check the connection "
                     "and try again."


### PR DESCRIPTION
## Summary
- avoid failing scanner connection when command dictionaries are empty

## Testing
- `pytest` *(fails: IndentationError in utilities/core/command_registry.py)*

------
https://chatgpt.com/codex/tasks/task_e_688ff3bba2b08324a3ee8cd9b9f8a8c5