### PR TITLE
Skip connection diagnostics in test mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -106,15 +106,20 @@ def main():
                     "Failed to connect to scanner. Please check the connection "
                     "and try again."
                 )
-                if (
-                    input(
-                        "\nWould you like to run connection diagnostics?"
-                        "(y/n): "
+                if not test_mode and sys.stdin.isatty():
+                    if (
+                        input(
+                            "\nWould you like to run connection diagnostics?"
+                            "(y/n): "
+                        )
+                        .lower()
+                        .startswith("y")
+                    ):
+                        diagnose_connection_issues()
+                else:
+                    logger.info(
+                        "Skipping connection diagnostics in test or non-interactive mode"
                     )
-                    .lower()
-                    .startswith("y")
-                ):
-                    diagnose_connection_issues()
                 logger.error("Failed to connect to scanner. Exiting.")
                 return
 


### PR DESCRIPTION
## Summary
- Skip connection diagnostics when scanner fails to connect during tests or non-interactive sessions
- Log when diagnostics are skipped to clarify behavior

## Testing
- `pytest -q` *(fails: IndentationError in utilities/core/command_registry.py)*

------
https://chatgpt.com/codex/tasks/task_e_688ff4889dfc83249d60db5949dcc4fb