### PR TITLE
Fix band scope capability detection in command registry

### DIFF
--- a/utilities/core/command_registry.py
+++ b/utilities/core/command_registry.py
@@ -207,11 +207,11 @@ def build_command_table(adapter, ser):
             "(Not available for this scanner model)"
         )
 
-    # Band scope (CSC streaming or manual sweep)
-    if hasattr(adapter, 'stream_custom_search'):
-
     # Band scope (CSC streaming or search sweep)
-    if hasattr(adapter, 'stream_custom_search') or hasattr(adapter, 'search_band_scope'):
+    if hasattr(adapter, 'stream_custom_search') or (
+        hasattr(adapter, 'search_band_scope')
+        and not hasattr(adapter, 'sweep_band_scope')
+    ):
         logging.debug("Registering 'band scope' command")
 
         def band_scope(ser_, adapter_, arg=""):


### PR DESCRIPTION
## Summary
- clean up leftover conditional in command registry
- ensure sweep-capable adapters use appropriate band scope implementation

## Testing
- `pytest tests/test_bc125at_band_scope.py::test_bc125at_band_scope_graph -q`


------
https://chatgpt.com/codex/tasks/task_e_688ffba4aa808324922c536eef7142fc