### PR TITLE
Send BC125AT keys in press mode

### DIFF
--- a/adapters/uniden/bc125at/user_control.py
+++ b/adapters/uniden/bc125at/user_control.py
@@ -27,8 +27,8 @@ def send_key(self, ser, key_seq):
             continue
         try:
             response = self.send_command(
-                ser, f"KEY,{char}"
-            )  # Remove the ,P parameter
+                ser, f"KEY,{char},P"
+            )  # Add ,P for "Press" mode
             responses.append(f"{char} → {response}")
         except Exception as e:
             responses.append(f"{char} → ERROR: {e}")


### PR DESCRIPTION
## Summary
- Send BC125AT scanner key commands in press mode for accurate emulation.

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after 33 tests due to serial communication errors)*

------
https://chatgpt.com/codex/tasks/task_e_68901c5ff2ec8324a8822ab8af8df5b7