### PR TITLE
Add SDR adapter support for RTL-SDR and RX888

### DIFF
--- a/adapters/sdr/__init__.py
+++ b/adapters/sdr/__init__.py
@@ -1,0 +1,5 @@
+"""Adapters for software-defined radios (SDR)."""
+from .rtlsdr_adapter import RTLSDRAdapter
+from .rx888_adapter import RX888Adapter
+
+__all__ = ["RTLSDRAdapter", "RX888Adapter"]

--- a/adapters/sdr/rtlsdr_adapter.py
+++ b/adapters/sdr/rtlsdr_adapter.py
@@ -1,0 +1,76 @@
+"""Adapter for RTL-SDR devices.
+
+This adapter provides a thin wrapper around cross-platform SDR libraries
+(SoapySDR or pyrtlsdr) exposing the small subset of functionality that the
+scanner controller expects.  The implementation is intentionally light weight
+so it can operate without the hardware present; methods fall back to cached
+values when the device is unavailable.
+"""
+
+from __future__ import annotations
+
+from adapters.base_adapter import BaseScannerAdapter
+
+try:  # pragma: no cover - optional dependency
+    import SoapySDR  # type: ignore
+    from SoapySDR import SOAPY_SDR_RX  # type: ignore
+except Exception:  # pragma: no cover
+    SoapySDR = None  # type: ignore
+    SOAPY_SDR_RX = 0  # type: ignore
+
+
+class RTLSDRAdapter(BaseScannerAdapter):
+    """Adapter implementation for RTL-SDR receivers."""
+
+    def __init__(self, device_args: dict | None = None, machine_mode: bool = False):
+        self.machine_mode = machine_mode
+        self._volume = 0.0
+        self._squelch = 0.0
+        self._device = None
+        if SoapySDR:  # pragma: no branch - executed when library available
+            args = device_args or {"driver": "rtlsdr"}
+            try:
+                self._device = SoapySDR.Device(args)
+            except Exception:  # pragma: no cover - runtime error if device missing
+                self._device = None
+
+    # ------------------------------------------------------------------
+    # Frequency control
+    def read_frequency(self, ser=None):  # pragma: no cover - hardware access
+        if self._device:
+            return self._device.getFrequency(SOAPY_SDR_RX, 0)
+        return 0.0
+
+    def write_frequency(self, ser, freq):  # pragma: no cover - hardware access
+        if self._device:
+            self._device.setFrequency(SOAPY_SDR_RX, 0, freq)
+        return freq
+
+    # ------------------------------------------------------------------
+    # Volume control - mapped to overall RF gain
+    def read_volume(self, ser=None):
+        if self._device:  # pragma: no branch - hardware access
+            try:
+                return float(self._device.getGain(SOAPY_SDR_RX, 0))
+            except Exception:
+                pass
+        return float(self._volume)
+
+    def write_volume(self, ser, value):
+        self._volume = float(value)
+        if self._device:  # pragma: no branch - hardware access
+            try:
+                self._device.setGain(SOAPY_SDR_RX, 0, float(value))
+            except Exception:
+                pass
+        return float(value)
+
+    # ------------------------------------------------------------------
+    # Squelch is not typically provided by SDR libraries.  We simply cache
+    # the value so higher layers have somewhere to store it.
+    def read_squelch(self, ser=None):
+        return float(self._squelch)
+
+    def write_squelch(self, ser, value):
+        self._squelch = float(value)
+        return float(value)

--- a/adapters/sdr/rx888_adapter.py
+++ b/adapters/sdr/rx888_adapter.py
@@ -1,0 +1,65 @@
+"""Adapter for RX888 based SDR receivers."""
+
+from __future__ import annotations
+
+from adapters.base_adapter import BaseScannerAdapter
+
+try:  # pragma: no cover - optional dependency
+    import SoapySDR  # type: ignore
+    from SoapySDR import SOAPY_SDR_RX  # type: ignore
+except Exception:  # pragma: no cover
+    SoapySDR = None  # type: ignore
+    SOAPY_SDR_RX = 0  # type: ignore
+
+
+class RX888Adapter(BaseScannerAdapter):
+    """Adapter implementation for RX888 receivers."""
+
+    def __init__(self, device_args: dict | None = None, machine_mode: bool = False):
+        self.machine_mode = machine_mode
+        self._volume = 0.0
+        self._squelch = 0.0
+        self._device = None
+        if SoapySDR:  # pragma: no branch
+            args = device_args or {"driver": "rx888"}
+            try:
+                self._device = SoapySDR.Device(args)
+            except Exception:  # pragma: no cover
+                self._device = None
+
+    # Frequency control
+    def read_frequency(self, ser=None):  # pragma: no cover
+        if self._device:
+            return self._device.getFrequency(SOAPY_SDR_RX, 0)
+        return 0.0
+
+    def write_frequency(self, ser, freq):  # pragma: no cover
+        if self._device:
+            self._device.setFrequency(SOAPY_SDR_RX, 0, freq)
+        return freq
+
+    # Volume control via gain
+    def read_volume(self, ser=None):
+        if self._device:  # pragma: no branch
+            try:
+                return float(self._device.getGain(SOAPY_SDR_RX, 0))
+            except Exception:
+                pass
+        return float(self._volume)
+
+    def write_volume(self, ser, value):
+        self._volume = float(value)
+        if self._device:  # pragma: no branch
+            try:
+                self._device.setGain(SOAPY_SDR_RX, 0, float(value))
+            except Exception:
+                pass
+        return float(value)
+
+    # Squelch placeholders
+    def read_squelch(self, ser=None):
+        return float(self._squelch)
+
+    def write_squelch(self, ser, value):
+        self._squelch = float(value)
+        return float(value)

--- a/command_libraries/sdr/__init__.py
+++ b/command_libraries/sdr/__init__.py
@@ -1,0 +1,14 @@
+"""Command abstractions for software-defined radios (SDR)."""
+from .sdr_commands import (
+    READ_FREQUENCY,
+    WRITE_FREQUENCY,
+    READ_VOLUME,
+    WRITE_VOLUME,
+)
+
+__all__ = [
+    "READ_FREQUENCY",
+    "WRITE_FREQUENCY",
+    "READ_VOLUME",
+    "WRITE_VOLUME",
+]

--- a/command_libraries/sdr/sdr_commands.py
+++ b/command_libraries/sdr/sdr_commands.py
@@ -1,0 +1,20 @@
+"""Simple command abstractions for generic SDR devices.
+
+These commands mirror the traditional command interfaces used by hardware
+scanners, allowing the rest of the application to interact with SDR based
+receivers using the same patterns.  They are intentionally minimal – the
+actual I/O is performed by the adapter using libraries such as SoapySDR or
+pyrtlsdr, but these command objects provide a consistent API surface so that
+high level utilities can remain largely unchanged.
+"""
+
+from command_libraries.base_command import BaseCommand
+
+# In the SDR context the commands do not correspond to serial strings.
+# They simply serve as placeholders to keep the command/adapter architecture
+# consistent with the rest of the project.
+
+READ_FREQUENCY = BaseCommand("READ_FREQUENCY")
+WRITE_FREQUENCY = BaseCommand("WRITE_FREQUENCY")
+READ_VOLUME = BaseCommand("READ_VOLUME")
+WRITE_VOLUME = BaseCommand("WRITE_VOLUME")

--- a/utilities/core/adapter_factory.py
+++ b/utilities/core/adapter_factory.py
@@ -31,12 +31,16 @@ def create_adapter(model_name, machine_mode=False):
         'bc125at': 'adapters.uniden.bc125at_adapter',
         'bcd325p2': 'adapters.uniden.bcd325p2_adapter',
         # Add more models as needed
+        'rtlsdr': 'adapters.sdr.rtlsdr_adapter',
+        'rx888': 'adapters.sdr.rx888_adapter',
     }
 
     class_map = {
         'bc125at': 'BC125ATAdapter',
         'bcd325p2': 'BCD325P2Adapter',
         # Add more models as needed
+        'rtlsdr': 'RTLSDRAdapter',
+        'rx888': 'RX888Adapter',
     }
 
     try:

--- a/utilities/scanner/factory.py
+++ b/utilities/scanner/factory.py
@@ -59,6 +59,16 @@ def get_scanner_adapter(model, machine_mode=False):
 
             logging.info(f"Creating adapter for {model}")
             return BCD325P2Adapter(machine_mode=machine_mode)
+        elif "RTLSDR" in model:
+            from adapters.sdr.rtlsdr_adapter import RTLSDRAdapter
+
+            logging.info(f"Creating adapter for {model}")
+            return RTLSDRAdapter(machine_mode=machine_mode)
+        elif "RX888" in model:
+            from adapters.sdr.rx888_adapter import RX888Adapter
+
+            logging.info(f"Creating adapter for {model}")
+            return RX888Adapter(machine_mode=machine_mode)
         else:
             prefixes = ("BC", "BCD", "UBC", "SDS")
             if any(model.startswith(prefix) for prefix in prefixes):


### PR DESCRIPTION
## Summary
- add RTLSDR and RX888 adapters built on SoapySDR
- include minimal SDR command abstractions for frequency/volume
- map new SDR models in core and scanner factories

## Testing
- `pytest tests/test_factory_uniden.py -q`
- `pytest -q` *(partial run; interrupted after 33 tests due to lengthy logging)*


------
https://chatgpt.com/codex/tasks/task_e_6890f4109cf48324a09d48405d13fbfb