### PR TITLE
Add SDR multichannel manager and virtual connection support

### DIFF
--- a/tests/test_multichannel_manager.py
+++ b/tests/test_multichannel_manager.py
@@ -1,0 +1,102 @@
+"""Tests for the SDR MultiChannelManager."""
+
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import types
+
+# Provide a minimal serial stub for modules that expect it
+serial_stub = types.ModuleType("serial")
+
+
+class DummySerial:
+    def __init__(self, *a, **k):
+        self.is_open = True
+
+    def close(self):  # pragma: no cover - trivial
+        self.is_open = False
+
+
+serial_stub.Serial = DummySerial
+serial_tools_stub = types.ModuleType("serial.tools")
+list_ports_stub = types.ModuleType("serial.tools.list_ports")
+list_ports_stub.comports = lambda *a, **k: []
+serial_tools_stub.list_ports = list_ports_stub
+serial_stub.tools = serial_tools_stub
+sys.modules["serial.tools"] = serial_tools_stub
+sys.modules["serial.tools.list_ports"] = list_ports_stub
+sys.modules["serial"] = serial_stub
+
+from utilities.scanner.connection_manager import ConnectionManager
+from utilities.sdr.multichannel_manager import MultiChannelManager, monitor_frequencies
+
+
+class DummyAdapter:
+    supports_ddc = True
+
+    def __init__(self, machine_mode: bool = False):
+        self.machine_mode = machine_mode
+        self.freqs = []
+
+    def send_command(self, ser, cmd):
+        return cmd
+
+    def write_frequency(self, ser, freq):
+        self.freqs.append(freq)
+        return freq
+
+    def read_frequency(self, ser):
+        return self.freqs[-1] if self.freqs else 0.0
+
+    def read_volume(self, ser):
+        return 0
+
+    def write_volume(self, ser, value):
+        return value
+
+    def read_squelch(self, ser):
+        return 0
+
+    def write_squelch(self, ser, value):
+        return value
+
+
+def test_monitor_frequencies_registers_virtual_connections():
+    adapter = DummyAdapter()
+    cm = ConnectionManager()
+    manager = MultiChannelManager(adapter)
+    conn_ids = manager.monitor_frequencies([100.0, 200.0], cm)
+    assert len(conn_ids) == 2
+    # Both channels should share the same adapter when supports_ddc is True
+    assert cm.get(conn_ids[0])[1] is adapter
+    assert cm.get(conn_ids[1])[1] is adapter
+    assert cm._hardware_refs[adapter] == 2
+    cm.close_connection(conn_ids[0])
+    assert adapter in cm._hardware_refs
+    cm.close_connection(conn_ids[1])
+    assert adapter not in cm._hardware_refs
+
+
+def test_monitor_frequencies_spawns_new_adapters():
+    class NoDDCAdapter(DummyAdapter):
+        supports_ddc = False
+
+    adapter = NoDDCAdapter()
+    cm = ConnectionManager()
+    manager = MultiChannelManager(adapter)
+    conn_ids = manager.monitor_frequencies([50.0, 75.0], cm)
+    assert len(conn_ids) == 2
+    first_adapter = cm.get(conn_ids[0])[1]
+    second_adapter = cm.get(conn_ids[1])[1]
+    assert first_adapter is not second_adapter
+    assert cm._hardware_refs[first_adapter] == 1
+    assert cm._hardware_refs[second_adapter] == 1
+
+
+def test_top_level_helper_uses_provided_adapter():
+    adapter = DummyAdapter()
+    cm = ConnectionManager()
+    ids = monitor_frequencies([10.0], adapter=adapter, connection_manager=cm)
+    assert ids and cm.get(ids[0])[1] is adapter

--- a/utilities/sdr/__init__.py
+++ b/utilities/sdr/__init__.py
@@ -1,0 +1,5 @@
+"""SDR utilities."""
+
+from .multichannel_manager import MultiChannelManager, monitor_frequencies
+
+__all__ = ["MultiChannelManager", "monitor_frequencies"]

--- a/utilities/sdr/multichannel_manager.py
+++ b/utilities/sdr/multichannel_manager.py
@@ -1,0 +1,76 @@
+"""Manage multiple virtual channels on an SDR device."""
+
+from __future__ import annotations
+
+from typing import List, Sequence
+
+from utilities.core.command_registry import build_command_table
+from utilities.scanner.connection_manager import ConnectionManager
+
+
+class MultiChannelManager:
+    """Monitor multiple frequencies using a single SDR adapter.
+
+    Additional channels either share the provided adapter through digital
+    down-conversion or spawn new adapter instances when that capability is
+    unavailable.  Each channel is registered with the :class:`ConnectionManager`
+    as a distinct logical connection.
+    """
+
+    def __init__(self, adapter):
+        self.adapter = adapter
+
+    def monitor_frequencies(
+        self, frequencies: Sequence[float], connection_manager: ConnectionManager
+    ) -> List[int]:
+        """Tune one or more frequencies and register them as connections."""
+
+        conn_ids: List[int] = []
+        base = self.adapter
+        for idx, freq in enumerate(frequencies):
+            if idx == 0 or getattr(base, "supports_ddc", False):
+                adapter = base
+                hardware = base
+            else:
+                # Spawn a new device instance for this channel
+                adapter = type(base)(machine_mode=getattr(base, "machine_mode", False))
+                hardware = adapter
+            adapter.write_frequency(None, freq)
+            commands, help_text = build_command_table(adapter, None)
+            conn_id = connection_manager.register_virtual_connection(
+                ser=None,
+                adapter=adapter,
+                commands=commands,
+                help_text=help_text,
+                hardware=hardware,
+            )
+            conn_ids.append(conn_id)
+        return conn_ids
+
+
+def monitor_frequencies(
+    frequencies: Sequence[float],
+    adapter=None,
+    connection_manager: ConnectionManager | None = None,
+) -> List[int]:
+    """High level helper used by CLI/GUI components.
+
+    Parameters
+    ----------
+    frequencies:
+        Frequencies to monitor (Hz).
+    adapter:
+        Optional SDR adapter instance.  When omitted an RTL-SDR adapter is
+        created.
+    connection_manager:
+        :class:`ConnectionManager` instance used to track the channels.  A new
+        instance is created if one is not supplied.
+    """
+
+    if adapter is None:
+        from adapters.sdr.rtlsdr_adapter import RTLSDRAdapter
+
+        adapter = RTLSDRAdapter()
+    cm = connection_manager or ConnectionManager()
+    manager = MultiChannelManager(adapter)
+    return manager.monitor_frequencies(frequencies, cm)


### PR DESCRIPTION
## Summary
- extend `ConnectionManager` with virtual connection and shared hardware support
- add SDR `MultiChannelManager` with `monitor_frequencies` helper
- cover multichannel behaviour with new tests

## Testing
- `pytest tests/test_multichannel_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890f601068c8324a11ab361dc236f16