### PR TITLE
Add SDR extras and cross-platform CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      - name: Run tests
+        run: pytest
+

--- a/README.md
+++ b/README.md
@@ -106,7 +106,59 @@ To include optional HID support, install the package with the `hid` extra:
 pip install .[hid]
 ```
 
+To enable optional SDR hardware support, install the package with the `sdr` extra:
+
+```bash
+pip install .[sdr]
+```
+
 4. Ensure the required scanner models are connected via serial ports.
+
+## SDR Device Setup
+
+Platform-specific drivers are required for RTL-SDR and other SDR hardware.
+
+### Windows
+
+1. Use [Zadig](https://zadig.akeo.ie/) to replace the default driver with **WinUSB**.
+2. Plug in the SDR and verify it appears as an *RTL2832U* device.
+3. Install optional Python packages with:
+
+   ```bash
+   pip install .[sdr]
+   ```
+
+### macOS
+
+1. Install drivers via [Homebrew](https://brew.sh/):
+
+   ```bash
+   brew install rtl-sdr soapysdr soapyrtlsdr
+   ```
+2. Install the Python extras with:
+
+   ```bash
+   pip install .[sdr]
+   ```
+
+### Linux
+
+1. Install drivers and udev rules from your package manager, for example on Debian/Ubuntu:
+
+   ```bash
+   sudo apt install rtl-sdr soapysdr-module-rtlsdr
+   ```
+2. If building from source, copy the provided udev rules and reload:
+
+   ```bash
+   sudo cp rtl-sdr.rules /etc/udev/rules.d/99-rtl-sdr.rules
+   sudo udevadm control --reload-rules && sudo udevadm trigger
+   ```
+3. Install the Python extras with:
+
+   ```bash
+   pip install .[sdr]
+   ```
 
 ## Enabling HID Devices on Linux
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,8 @@ skip_glob = [".venv/*", ".pytest_cache/*", ".github/*", "__pycache__/*"]
 
 [project.optional-dependencies]
 hid = ["hid==1.0.*"]
+sdr = [
+    "pyrtlsdr",
+    "SoapySDR",
+    "SoapyRTLSDR",
+]


### PR DESCRIPTION
## Summary
- add `sdr` optional dependencies for pyrtlsdr, SoapySDR and SoapyRTLSDR
- document SDR setup for Windows, macOS and Linux
- run tests on Linux, Windows and macOS via GitHub Actions

## Testing
- `python -m pip install -r requirements.txt` *(failed: Could not find a version that satisfies iso8601==2.1.0)*
- `pre-commit run --files pyproject.toml README.md .github/workflows/ci.yml` *(failed: unable to fetch hooks due to 403)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890faf570108324a8e0b2f1cbd471de