### PR TITLE
Add Boondock Echo configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ pip install .[sdr]
 
 4. Ensure the required scanner models are connected via serial ports.
 
+## Configuration
+
+The application can interact with the Boondock Echo service. Configure the
+service connection using these environment variables:
+
+- `BOONDOCK_API_URL`: Base URL for the Boondock Echo API. Defaults to
+  `http://localhost:8000/audio`.
+- `BOONDOCK_AUTH_TOKEN`: Optional token used for authenticated requests.
+
 ## SDR Device Setup
 
 Platform-specific drivers are required for RTL-SDR and other SDR hardware.

--- a/config/boondock_echo.py
+++ b/config/boondock_echo.py
@@ -1,16 +1,11 @@
-"""Configuration for the Boondock Echo service."""
-
-from __future__ import annotations
+"""Boondock Echo service configuration."""
 
 import os
 
-# Default API endpoint for the Boondock Echo service. Override with the
-# ``BOONDOCK_ECHO_API_URL`` environment variable.
-DEFAULT_API_URL = "http://localhost:8000/audio"
-API_URL = os.getenv("BOONDOCK_ECHO_API_URL", DEFAULT_API_URL)
 
-# Authorization token used when communicating with the service. Override with
-# the ``BOONDOCK_ECHO_AUTH_TOKEN`` environment variable.
-AUTH_TOKEN = os.getenv("BOONDOCK_ECHO_AUTH_TOKEN", "")
+API_URL = os.getenv("BOONDOCK_API_URL", "http://localhost:8000/audio")
+AUTH_TOKEN = os.getenv("BOONDOCK_AUTH_TOKEN", "")
 
-__all__ = ["API_URL", "AUTH_TOKEN", "DEFAULT_API_URL"]
+
+__all__ = ["API_URL", "AUTH_TOKEN"]
+


### PR DESCRIPTION
## Summary
- define Boondock Echo API settings via `BOONDOCK_API_URL` and `BOONDOCK_AUTH_TOKEN`
- document Boondock Echo environment variables in README

## Testing
- `pre-commit run --files config/boondock_echo.py README.md` *(fails: unable to access 'https://github.com/pre-commit/pre-commit-hooks/' 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68911811f8188324955040ece73beebd