### PR TITLE
Explicitly configure package discovery for setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,17 @@ sdr = [
     "SoapyRTLSDR",
 ]
 
+[tool.setuptools.packages.find]
+include = [
+    "command_libraries",
+    "config",
+    "dev_tools",
+    "utilities",
+    "scanner_gui",
+    "adapters",
+]
+exclude = ["logs", "tests"]
+
 [tool.black]
 target-version = ['py38']
 include = '\.pyi?$'


### PR DESCRIPTION
## Summary
- specify project packages and excludes in pyproject.toml

## Testing
- `python -m pip install .[hid]` *(fails: invalid command 'bdist_wheel')*
- `pytest -q` *(33 passed, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68923599b3c48324b232e46817d8cef9