### PR TITLE
chore: centralize extras definition

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,3 @@ include_trailing_comma = true
 use_parentheses = true
 ensure_newline_before_comments = true
 
-[options.extras_require]
-hid =
-    hid==1.0.*


### PR DESCRIPTION
## Summary
- remove redundant extras definition from setup.cfg so project extras come from pyproject.toml

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `pytest -q` *(fails: KeyboardInterrupt after 33 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6892374fef588324b19e1a043c925995