### PR TITLE
Guard Soapy SDR dependencies on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ dependencies = [
 hid = ["hid==1.0.*"]
 sdr = [
     "pyrtlsdr",
-    "SoapySDR",
-    "SoapyRTLSDR",
+    "SoapySDR; platform_system != 'Windows'",
+    "SoapyRTLSDR; platform_system != 'Windows'",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary
- add platform markers so SoapySDR packages are skipped on Windows while pyrtlsdr is always included

## Testing
- `python - <<'PY'
import tomllib
from pathlib import Path
from packaging.requirements import Requirement
from packaging.markers import default_environment
content = tomllib.loads(Path('pyproject.toml').read_text())
reqs = content['project']['optional-dependencies']['sdr']
req_objs = [Requirement(r) for r in reqs]
for env_name in ['Windows', 'Linux']:
    env = default_environment(); env['platform_system'] = env_name
    resolved = [r.name for r in req_objs if r.marker is None or r.marker.evaluate(env)]
    print(env_name, '->', resolved)
PY`
- `python -m pip install .[sdr] --dry-run --no-deps --platform win32 --no-build-isolation` *(fails: invalid command 'bdist_wheel')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892a72f932c8324b3068aa570d38139