### PR TITLE
docs: detail windows sdr setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,13 @@ Platform-specific drivers are required for RTL-SDR and other SDR hardware.
 
 1. Use [Zadig](https://zadig.akeo.ie/) to replace the default driver with **WinUSB**.
 2. Plug in the SDR and verify it appears as an *RTL2832U* device.
-3. Install optional Python packages with:
+3. Install the RTL-SDR Python package:
 
    ```bash
-   pip install .[sdr]
+   pip install pyrtlsdr
    ```
+4. (Optional) Install a SoapySDR runtime for full control via [PothosSDR](https://github.com/pothosware/PothosSDR/wiki/Downloads) or [Chocolatey](https://community.chocolatey.org/packages/pothos-sdr).
+5. `pip install .[sdr]` on Windows installs `pyrtlsdr` but skips SoapySDR packages. Advanced users can add those packages manually after setting up a runtime.
 
 ### macOS
 


### PR DESCRIPTION
## Summary
- Clarify Windows SDR setup steps, including driver installation with Zadig, installing `pyrtlsdr`, optional SoapySDR via PothosSDR or Chocolatey, and note that `pip install .[sdr]` skips Soapy packages.

## Testing
- `pytest` *(interrupted: KeyboardInterrupt after 33 tests)*


------
https://chatgpt.com/codex/tasks/task_e_6892ab9fc26c8324b4643d1e02123e90