### PR TITLE
Enumerate rtlsdr when SoapySDR finds no devices

### DIFF
--- a/scanner_controller/utilities/scanner/backend.py
+++ b/scanner_controller/utilities/scanner/backend.py
@@ -101,7 +101,7 @@ def find_all_scanner_ports(
                 logging.warning(f"Error testing HID device {hid_path}: {e}")
         if detected:
             return detected
-    # Attempt SDR device scan if available
+    # Attempt SDR device scans if available
     try:  # pragma: no cover - optional dependency
         from SoapySDR import Device  # type: ignore
 
@@ -112,14 +112,16 @@ def find_all_scanner_ports(
             detected.append((f"{driver}:{idx}", friendly))
     except Exception as e:  # pragma: no cover - best effort
         logging.info(f"SoapySDR enumeration unavailable: {e}")
-        try:  # pragma: no cover - optional dependency
-            from rtlsdr import RtlSdr  # type: ignore
 
-            logging.info("Checking for SDR devices via pyrtlsdr")
-            for idx, _ in enumerate(RtlSdr.get_devices()):
-                detected.append((f"rtlsdr:{idx}", "RTLSDR"))
-        except Exception as e2:  # pragma: no cover - best effort
-            logging.info(f"pyrtlsdr enumeration unavailable: {e2}")
+    try:  # pragma: no cover - optional dependency
+        from rtlsdr import RtlSdr  # type: ignore
+
+        logging.info("Checking for SDR devices via pyrtlsdr")
+        for idx, _ in enumerate(RtlSdr.get_devices()):
+            detected.append((f"rtlsdr:{idx}", "RTLSDR"))
+    except Exception as e2:  # pragma: no cover - best effort
+        logging.info(f"pyrtlsdr enumeration unavailable: {e2}")
+
     if detected:
         return detected
     return []


### PR DESCRIPTION
## Summary
- Probe SDRs via SoapySDR but always also query pyrtlsdr devices
- Add regression test for rtlsdr detection when SoapySDR returns no devices

## Testing
- `pre-commit run --files scanner_controller/utilities/scanner/backend.py tests/test_backend_port_generator.py` *(failed: fatal unable to access 'https://github.com/pre-commit/pre-commit-hooks/' 403)*
- `PYTHONPATH=. pytest tests/test_backend_port_generator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6892bd1b805483249286d41144166697