### PR TITLE
Clarify setuptools packages for distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,16 @@ sdr = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["scanner_controller", "scanner_controller.*"]
+include = [
+    "scanner_controller",
+    "scanner_controller.command_libraries",
+    "scanner_controller.config",
+    "scanner_controller.dev_tools",
+    "scanner_controller.utilities",
+    "scanner_controller.scanner_gui",
+    "scanner_controller.adapters",
+    "scanner_controller.adapters.*",
+]
 exclude = ["logs", "tests"]
 
 [tool.black]


### PR DESCRIPTION
## Summary
- Explicitly enumerate scanner_controller subpackages for setuptools
- Ensure logs and tests directories are excluded from distribution

## Testing
- `pytest tests/test_adapter_close_call.py::test_scan_controls_return_raw -q`
- `pip install .[hid]` *(fails: could not find a version that satisfies setuptools>=61)*

------
https://chatgpt.com/codex/tasks/task_e_6892bff84a6c8324a247df90523ba468