### PR TITLE
Clarify build system configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
+# Build system configuration
 [build-system]
 requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- note the setuptools build backend in `pyproject.toml`

## Testing
- `python -m pip install . --no-deps --no-build-isolation` *(fails: invalid command 'bdist_wheel')*
- `python -m pip install wheel` *(fails: Could not find a version that satisfies the requirement wheel)*
- `pre-commit run --files pyproject.toml` *(fails: unable to fetch pre-commit hooks)*

------
https://chatgpt.com/codex/tasks/task_e_6892c2a379188324a2a9a79a3e554536