### PR TITLE
Streamline package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,15 +27,10 @@ sdr = [
 ]
 
 [tool.setuptools.packages.find]
+# Automatically include the main package and all subpackages.
 include = [
     "scanner_controller",
-    "scanner_controller.command_libraries",
-    "scanner_controller.config",
-    "scanner_controller.dev_tools",
-    "scanner_controller.utilities",
-    "scanner_controller.scanner_gui",
-    "scanner_controller.adapters",
-    "scanner_controller.adapters.*",
+    "scanner_controller.*",
 ]
 exclude = ["logs", "tests"]
 


### PR DESCRIPTION
## Summary
- simplify setuptools package discovery to include scanner_controller and submodules via wildcard pattern

## Testing
- `pre-commit run --files pyproject.toml` *(fails: CONNECT tunnel failed, response 403)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6892c792cc908324a62387f7e9bd998c